### PR TITLE
feat: separate Compressor and Decompressor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0"
 repository = "https://github.com/spiraldb/fsst"
 edition = "2021"
 
+[lib]
+name = "fsst"
+
 [lints.rust]
 warnings = "deny"
 missing_docs = "deny"

--- a/examples/file_compressor.rs
+++ b/examples/file_compressor.rs
@@ -19,6 +19,8 @@ use std::{
     path::Path,
 };
 
+use fsst::Compressor;
+
 fn main() {
     let args: Vec<_> = std::env::args().skip(1).collect();
     assert!(args.len() >= 2, "args TRAINING and FILE must be provided");
@@ -33,7 +35,7 @@ fn main() {
     }
 
     println!("building the compressor from {train_path:?}...");
-    let compressor = fsst_rs::train(&train_bytes);
+    let compressor = Compressor::train(&train_bytes);
 
     println!("compressing blocks of {input_path:?} with compressor...");
 

--- a/examples/round_trip.rs
+++ b/examples/round_trip.rs
@@ -2,14 +2,16 @@
 
 use core::str;
 
+use fsst::Compressor;
+
 fn main() {
     // Train on a sample.
     let sample = "the quick brown fox jumped over the lazy dog";
-    let trained = fsst_rs::train(sample.as_bytes());
+    let trained = Compressor::train(sample.as_bytes());
     let compressed = trained.compress(sample.as_bytes());
     println!("compressed: {} => {}", sample.len(), compressed.len());
     // decompress now
-    let decode = trained.decompress(&compressed);
+    let decode = trained.decompressor().decompress(&compressed);
     let output = str::from_utf8(&decode).unwrap();
     println!(
         "decoded to the original: len={} text='{}'",

--- a/fuzz/fuzz_targets/fuzz_compress.rs
+++ b/fuzz/fuzz_targets/fuzz_compress.rs
@@ -3,8 +3,9 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    let table = fsst_rs::train("the quick brown fox jumped over the lazy dog".as_bytes());
-    let compress = table.compress(data);
-    let decompress = table.decompress(&compress);
+    let compressor =
+        fsst::Compressor::train("the quick brown fox jumped over the lazy dog".as_bytes());
+    let compress = compressor.compress(data);
+    let decompress = compressor.decompressor().decompress(&compress);
     assert_eq!(&decompress, data);
 });

--- a/fuzz/fuzz_targets/fuzz_train.rs
+++ b/fuzz/fuzz_targets/fuzz_train.rs
@@ -3,5 +3,5 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = fsst_rs::train(data);
+    let _ = fsst::Compressor::train(data);
 });

--- a/src/find_longest/naive.rs
+++ b/src/find_longest/naive.rs
@@ -1,11 +1,11 @@
 use crate::find_longest::FindLongestSymbol;
-use crate::SymbolTable;
+use crate::Compressor;
 
 // Find the code that maps to a symbol with longest-match to a piece of text.
 //
 // This is the naive algorithm that just scans the whole table and is very slow.
 
-impl FindLongestSymbol for SymbolTable {
+impl FindLongestSymbol for Compressor {
     // NOTE(aduffy): if you don't disable inlining, this function won't show up in profiles.
     #[inline(never)]
     fn find_longest_symbol(&self, text: &[u8]) -> u16 {


### PR DESCRIPTION
As part of implementing the vortex `FSSTArray`, we should separate out the data for compression (symbol table, hash table, codes_twobyte vector) and decompression (just the symbol table).

This PR separates the previous `SymbolTable` type into two types, a `Compressor` and a `Decompressor<'a>`. A Compressor can be trained on a sample text, as before, but it does not have decompression methods. Those are now on a new `Decompressor` type. Decompressors can either be built directly from a Compressor, or you can build one by directly wrapping a `&[Symbol]`. Compressors allow slice access to the symbol table as well, e.g. for serialization