### PR TITLE
feat: make Compressor::train 2x faster with bitmap index

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -3,7 +3,6 @@ name: Miri
 on:
   push:
     branches: ["develop"]
-  pull_request: {}
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -3,6 +3,7 @@ name: Miri
 on:
   push:
     branches: ["develop"]
+  pull_request: {}
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,52 @@
+name: Miri
+
+on:
+  push:
+    branches: ["develop"]
+  pull_request: {}
+  workflow_dispatch: {}
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  miri:
+    name: "miri"
+    runs-on: ubuntu-latest
+    env:
+      RUST_BACKTRACE: 1
+      MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-backtrace=full
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Rust Version
+        id: rust-version
+        shell: bash
+        run: echo "version=$(cat rust-toolchain.toml | grep channel | awk -F'\"' '{print $2}')" >> $GITHUB_OUTPUT
+
+      - name: Rust Toolchain
+        id: rust-toolchain
+        uses: dtolnay/rust-toolchain@master
+        if: steps.rustup-cache.outputs.cache-hit != 'true'
+        with:
+          toolchain: "${{ steps.rust-version.outputs.version }}"
+          components: miri
+
+      - name: Rust Dependency Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/develop' }}
+          shared-key: "shared" # To allow reuse across jobs
+
+      - name: Rust Compile Cache
+        uses: mozilla-actions/sccache-action@v0.0.5
+      - name: Rust Compile Cache Config
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
+
+      - name: Run tests with Miri
+        run: cargo miri test

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -11,14 +11,12 @@ use crate::{Compressor, Symbol, ESCAPE_CODE, MAX_CODE};
 
 /// Bitmap that only works for values up to 512
 #[derive(Clone, Copy, Debug, Default)]
-#[allow(dead_code)]
 struct CodesBitmap {
     codes: [u64; 8],
 }
 
 assert_sizeof!(CodesBitmap => 64);
 
-#[allow(dead_code)]
 impl CodesBitmap {
     /// Set the indicated bit. Must be between 0 and [`MAX_CODE`][crate::MAX_CODE].
     pub(crate) fn set(&mut self, index: usize) {
@@ -94,7 +92,7 @@ struct Counter {
     /// Bitmap index of pairs that have been set.
     ///
     /// `pair_index[code1].codes()` yields an iterator that can
-    /// be used to find the values of codes in the outside iterator.
+    /// be used to find all possible codes that follow `codes1`.
     pair_index: Vec<CodesBitmap>,
 }
 
@@ -135,7 +133,11 @@ impl Counter {
         self.counts2[idx]
     }
 
-    /// Access to the second-code in a code pair following `code1`.
+    /// Returns an iterator over the codes that have been observed
+    /// to follow `code1`.
+    ///
+    /// This is the set of all values `code2` where there was
+    /// previously a call to `self.record_count2(code1, code2)`.
     fn second_codes(&self, code1: u16) -> CodesIterator {
         self.pair_index[code1 as usize].codes()
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -146,7 +146,10 @@ impl Counter {
 /// The number of generations used for training. This is taken from the [FSST paper].
 ///
 /// [FSST paper]: https://www.vldb.org/pvldb/vol13/p2649-boncz.pdf
+#[cfg(not(miri))]
 const MAX_GENERATIONS: usize = 5;
+#[cfg(miri)]
+const MAX_GENERATIONS: usize = 2;
 
 impl Compressor {
     /// Build and train a `Compressor` from a sample corpus of text.

--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -47,16 +47,13 @@ fn test_one_byte() {
 
 #[test]
 fn test_zeros() {
-    println!("training zeros");
     let training_data: Vec<u8> = vec![0, 1, 2, 3, 4, 0];
     let trained = Compressor::train(&training_data);
-    println!("compressing with zeros");
     let compressed = trained.compress(&[4, 0]);
-    println!("decomperssing with zeros");
     assert_eq!(trained.decompressor().decompress(&compressed), &[4, 0]);
-    println!("done");
 }
 
+#[cfg_attr(miri, ignore)]
 #[test]
 fn test_large() {
     let corpus: Vec<u8> = DECLARATION.bytes().cycle().take(10_240).collect();


### PR DESCRIPTION
The slowest part of Compressor::train is the double-nested loops over codes.

Now compress_count when it records code pairs will also populate a bitmap index, where `pairs_index[code1].set(code2)` will indicate that code2 followed code1 in compressed output.

In the `optimize` loop, we can eliminate tight loop iterations by accessing `pairse_index[code1].second_codes()` which yields the value code2 values.

This results in a speedup from ~1ms -> 500micros for the training benchmark. We're sub-millisecond!

This also makes Miri somewhat palatable to run for all but `test_large`, so I've re-enabled it for CI (currently it runs in 2.5 minutes. Far cry from the < 30s build+test step but I guess it's for a good cause)