### PR TITLE
add single bytes as candidates

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -252,6 +252,14 @@ impl Compressor {
             counter.record_count1(code);
             counter.record_count2(prev_code, code);
 
+            // Record the first byte of `code` as its own symbol so that it is a candidate for merging
+            // with `prev_code`. This allows us to grow the symbol table by one byte rather than
+            // concatenating a full symbol.
+            if code >= 256 {
+                let first_byte = self.symbols[code as usize].first_byte();
+                counter.record_count2(prev_code, first_byte as u16);
+            }
+
             prev_code = code;
         }
     }


### PR DESCRIPTION
From the paper section 4.2

![image](https://github.com/user-attachments/assets/9e6af183-8391-420f-934a-6a04e550414d)

This seems to slightly reduce throughput on the compression benchmark, I'm not sure if it's because this sample just ends up with a slightly less-optimal symbol table or what