### PR TITLE
feat: reuse and clear instead of allocate, 2x speedup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,9 +320,6 @@ pub struct Compressor {
     /// the escape values.
     pub(crate) n_symbols: u8,
 
-    //
-    // Index structures used to speedup building the symbol table and compression
-    //
     /// Inverted index mapping 2-byte symbols to codes
     codes_twobyte: Vec<CodeMeta>,
 
@@ -371,7 +368,7 @@ impl Compressor {
             // Insert the 2-byte symbol into the twobyte cache
             self.codes_twobyte[symbol.first_two_bytes() as usize] =
                 CodeMeta::new_symbol(self.n_symbols, symbol);
-        } else if symbol_len >= 3 {
+        } else {
             // Attempt to insert larger symbols into the 3-byte cache
             if !self.lossy_pht.insert(symbol, self.n_symbols) {
                 return false;

--- a/src/lossy_pht.rs
+++ b/src/lossy_pht.rs
@@ -60,12 +60,14 @@ pub(crate) struct LossyPHT {
 impl LossyPHT {
     /// Construct a new empty lossy perfect hash table
     pub(crate) fn new() -> Self {
-        let slots = [TableEntry {
-            symbol: Symbol::ZERO,
-            code: CodeMeta::EMPTY,
-            ignored_bits: 64,
-        }]
-        .repeat(HASH_TABLE_SIZE);
+        let slots = vec![
+            TableEntry {
+                symbol: Symbol::ZERO,
+                code: CodeMeta::EMPTY,
+                ignored_bits: 64,
+            };
+            HASH_TABLE_SIZE
+        ];
 
         Self { slots }
     }
@@ -90,6 +92,13 @@ impl LossyPHT {
             entry.ignored_bits = (64 - 8 * symbol.len()) as u16;
             true
         }
+    }
+
+    /// Remove the symbol from the hashtable, if it exists.
+    pub(crate) fn remove(&mut self, symbol: Symbol) {
+        let prefix_3bytes = symbol.as_u64() & 0xFF_FF_FF;
+        let slot = self.hash(prefix_3bytes) as usize & (HASH_TABLE_SIZE - 1);
+        self.slots[slot].code = CodeMeta::EMPTY;
     }
 
     #[inline]


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/88e720e3-ca29-4cf4-b59a-2315c89393f0)

Adds `clear` method on `Compressor`, `Counter`, `CodesBitmap`, removal method on `LossyPHT`.

This allows us to reuse `Compressor` in the training tight loop rather than reinitializing, since building a Compressor is quite expensive