### PR TITLE
fix: assertion should not fail if input was empty string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,7 +501,7 @@ impl Compressor {
         // SAFETY: assertion
         let bytes_written = out_ptr.offset_from(values.as_ptr());
         assert!(
-            bytes_written.is_positive(),
+            bytes_written >= 0,
             "out_ptr ended before it started, not possible"
         );
 


### PR DESCRIPTION
The lower-level methods support empty, but this assertion on the wrapper was causing failures when empty plaintext provided