### PR TITLE
feat: 35% faster decompression with less boundary check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,7 +270,7 @@ impl<'a> Decompressor<'a> {
                 // SAFETY: out_pos is always 8 bytes or more from the end of decoded buffer
                 // SAFETY: ESCAPE_CODE can not be the last byte of the compressed stream
                 unsafe {
-                    let write_addr = ptr.add(out_pos);
+                    let write_addr = ptr.byte_add(out_pos);
                     std::ptr::write(write_addr, *compressed.get_unchecked(in_pos));
                 }
                 out_pos += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,7 +282,7 @@ impl<'a> Decompressor<'a> {
                 let length = unsafe { *self.lengths.get_unchecked(code as usize) };
                 // SAFETY: out_pos is always 8 bytes or more from the end of decoded buffer
                 unsafe {
-                    let write_addr = ptr.add(out_pos) as *mut u64;
+                    let write_addr = ptr.byte_add(out_pos) as *mut u64;
                     // Perform 8 byte unaligned write.
                     write_addr.write_unaligned(symbol.as_u64());
                 }


### PR DESCRIPTION
Hi SpiralDB devs! First of all, thank you for implementing the great FSST library!

While profiling a decompression workload, I noticed we have some unintended boundary checks that could be removed to improve decompression throughput by 35%, as shown in the `decompress` benchmark below.

Removing those boundary checks requires more unsafe code, I've mannually annotated their correctness, but please double check! cc @alamb who might be interested

```
cargo bench --bench micro decompress

   Compiling fsst-rs v0.4.2 (/home/hao/coding/fsst)
    Finished `bench` profile [optimized] target(s) in 0.86s
     Running benches/micro.rs (target/release/deps/micro-bf2c70cedbbe0467)
Gnuplot not found, using plotters backend
cf=8/decompress         time:   [47.687 µs 47.725 µs 47.768 µs]
                        thrpt:  [20.444 GiB/s 20.462 GiB/s 20.478 GiB/s]
                 change:
                        time:   [-26.409% -26.311% -26.208%] (p = 0.00 < 0.05)
                        thrpt:  [+35.517% +35.705% +35.887%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe
```