### PR TITLE
feat: add dbtext decompression benchmark

### DIFF
--- a/benches/compress.rs
+++ b/benches/compress.rs
@@ -82,6 +82,14 @@ fn bench_dbtext(c: &mut Criterion) {
             b.iter(|| unsafe { compressor.compress_into(&buf, &mut buffer) });
         });
 
+        unsafe {
+            compressor.compress_into(&buf, &mut buffer);
+        };
+        let decompressor = compressor.decompressor();
+        group.bench_function("decompress", |b| {
+            b.iter_with_large_drop(|| decompressor.decompress(&buffer));
+        });
+
         group.finish();
 
         // Report the compression factor for this dataset.


### PR DESCRIPTION
1. Is decompression throughput typically defined as bytes/s of input or output?
2. Decompression's measured speed is fast, but the iterations are slow due to large drop. Criterion complains that it doesn't get 100 samples in 5s. I could increase the sample time or reduce the minimum samples. If there was a analogous `decompress_into` function the memory could be reused and this wouldn't be an issue.