### PR TITLE
Assert enough room in decoded buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,15 +115,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "criterion"
-version = "0.5.1"
+name = "codspeed"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "60e744216bfa9add3b1f2505587cbbb837923232ed10963609f4a6e3cbd99c3e"
+dependencies = [
+ "colored",
+ "libc",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5926ca63222a35b9a2299adcaafecf596efe20a9a2048e4a81cb2fc3463b4a8"
+dependencies = [
+ "codspeed",
+ "codspeed-criterion-compat-walltime",
+ "colored",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbae4da05076cbc673e242400ac8f4353bdb686e48020edc6e36a5c36ae0878e"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
+ "codspeed",
  "criterion-plot",
  "is-terminal",
  "itertools",
@@ -132,6 +163,16 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "walkdir",
+]
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -215,8 +256,20 @@ checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
 name = "fsst-rs"
 version = "0.5.0"
 dependencies = [
- "criterion",
+ "codspeed-criterion-compat",
  "curl",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -270,6 +323,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -547,6 +606,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
+name = "uuid"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +628,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
 ]
 
 [[package]]
@@ -720,3 +797,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,11 +285,7 @@ impl<'a> Decompressor<'a> {
     /// unsafe { decompressed.set_len(len) };
     /// assert_eq!(&decompressed, "helloooo".as_bytes());
     /// ```
-    pub fn decompress_into(
-        &self,
-        compressed: &[u8],
-        decoded: &mut [MaybeUninit<u8>],
-    ) -> usize {
+    pub fn decompress_into(&self, compressed: &[u8], decoded: &mut [MaybeUninit<u8>]) -> usize {
         // Ensure the target buffer is at least half the size of the input buffer.
         // This is the theortical smallest a valid target can be, and occurs when
         // every input code is an escape.
@@ -308,7 +304,10 @@ impl<'a> Decompressor<'a> {
 
         while in_pos < compressed.len() {
             // out_pos can grow at most 8 bytes per iteration, and we start at 0
-            assert!(out_pos <= decoded_end, "Insufficient space in output buffer");
+            assert!(
+                out_pos <= decoded_end,
+                "Insufficient space in output buffer"
+            );
 
             // SAFETY: in_pos is always in range 0..compressed.len()
             let code = unsafe { *compressed.get_unchecked(in_pos) };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,10 +261,10 @@ impl<'a> Decompressor<'a> {
     /// The provided `decoded` buffer must be at least the size of the decoded data, plus
     /// an additional 7 bytes.
     ///
-    /// ## Safety
+    /// ## Panics
     ///
-    /// It is the caller's responsibility to ensure the provided `decoded` slice is large enough to contain
-    /// the decompressed string data. If not, arbitrary memory may be overwritten.
+    /// If the caller fails to provide sufficient capacity in the decoded buffer. An upper bound
+    /// on the required capacity can be obtained by calling [`Self::max_decompression_capacity`].
     ///
     /// ## Example
     ///
@@ -299,12 +299,16 @@ impl<'a> Decompressor<'a> {
         );
         let ptr: *mut u8 = decoded.as_mut_ptr().cast();
 
+        // We need to assert that `out_pos + size_of::<Symbol>() < decoded.len()`, so we hoist
+        // out `decoded.len() - size_of::<Symbol>()` into a variable.
+        let decoded_end = decoded.len() - size_of::<Symbol>();
+
         let mut in_pos = 0;
         let mut out_pos = 0;
 
         while in_pos < compressed.len() {
             // out_pos can grow at most 8 bytes per iteration, and we start at 0
-            assert!(out_pos + size_of::<Symbol>() <= decoded.len(), "Insufficient space in output buffer");
+            assert!(out_pos <= decoded_end, "Insufficient space in output buffer");
 
             // SAFETY: in_pos is always in range 0..compressed.len()
             let code = unsafe { *compressed.get_unchecked(in_pos) };
@@ -324,14 +328,15 @@ impl<'a> Decompressor<'a> {
                 // The symbol and length tables are both of length 256, so this is safe.
                 let symbol = unsafe { *self.symbols.get_unchecked(code as usize) };
                 let length = unsafe { *self.lengths.get_unchecked(code as usize) };
+
                 // SAFETY: out_pos is always 8 bytes or more from the end of decoded buffer
                 unsafe {
                     let write_addr = ptr.byte_add(out_pos) as *mut u64;
                     // Perform 8 byte unaligned write.
                     write_addr.write_unaligned(symbol.as_u64());
                 }
-                in_pos += 1;
                 out_pos += length as usize;
+                in_pos += 1;
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,14 +280,12 @@ impl<'a> Decompressor<'a> {
     ///
     /// let mut decompressed = Vec::with_capacity(8 + 7);
     ///
-    /// unsafe {
-    ///     let len = decompressor.decompress_into(&[0], decompressed.spare_capacity_mut());
-    ///     assert_eq!(len, 8);
-    ///     decompressed.set_len(len);
-    /// }
+    /// let len = decompressor.decompress_into(&[0], decompressed.spare_capacity_mut());
+    /// assert_eq!(len, 8);
+    /// unsafe { decompressed.set_len(len) };
     /// assert_eq!(&decompressed, "helloooo".as_bytes());
     /// ```
-    pub unsafe fn decompress_into(
+    pub fn decompress_into(
         &self,
         compressed: &[u8],
         decoded: &mut [MaybeUninit<u8>],
@@ -306,7 +304,8 @@ impl<'a> Decompressor<'a> {
 
         while in_pos < compressed.len() {
             // out_pos can grow at most 8 bytes per iteration, and we start at 0
-            debug_assert!(out_pos <= decoded.len() - size_of::<Symbol>());
+            assert!(out_pos + size_of::<Symbol>() <= decoded.len(), "Insufficient space in output buffer");
+
             // SAFETY: in_pos is always in range 0..compressed.len()
             let code = unsafe { *compressed.get_unchecked(in_pos) };
             if code == ESCAPE_CODE {
@@ -349,8 +348,8 @@ impl<'a> Decompressor<'a> {
     pub fn decompress(&self, compressed: &[u8]) -> Vec<u8> {
         let mut decoded = Vec::with_capacity(self.max_decompression_capacity(compressed) + 7);
 
-        // SAFETY: we allocate the maximum decompression memory possible for decoded.
-        let len = unsafe { self.decompress_into(compressed, decoded.spare_capacity_mut()) };
+        let len = self.decompress_into(compressed, decoded.spare_capacity_mut());
+        // SAFETY: len bytes have now been initialized by the decompressor.
         unsafe { decoded.set_len(len) };
         decoded
     }


### PR DESCRIPTION
C++ version includes this check too `posOut+32 <= size`:
https://github.com/carlopi/duckdb/blob/b2f613b238a9ca7b739b76dac6fd8dd551dea817/third_party/fsst/fsst.h#L177

We should not trust that the caller has reserved sufficient space.