### PR TITLE
feat: add rebuild from existing function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "Pure-Rust implementation of Fast Static Symbol Tables algorithm f
 authors = ["SpiralDB Developers <hello@spiraldb.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/spiraldb/fsst"
-edition = "2021"
+edition = "2024"
 
 [lib]
 name = "fsst"

--- a/benches/compress.rs
+++ b/benches/compress.rs
@@ -10,7 +10,7 @@ use std::{
     path::Path,
 };
 
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 
 use curl::easy::Easy;
 use fsst::Compressor;

--- a/benches/micro.rs
+++ b/benches/micro.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 
 use fsst::{CompressorBuilder, Symbol};
 

--- a/examples/file_compressor.rs
+++ b/examples/file_compressor.rs
@@ -27,7 +27,7 @@ fn main() {
         let mut f = File::open(input_path).unwrap();
         f.read_to_string(&mut string).unwrap();
     }
-    let uncompressed_size = string.as_bytes().len();
+    let uncompressed_size = string.len();
     let lines: Vec<&[u8]> = string.lines().map(|line| line.as_bytes()).collect();
 
     // let mut output = File::create(output_path).unwrap();

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "fsst-rs"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "fsst-rs-fuzz"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fsst-rs-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/fuzz_targets/fuzz_compress.rs
+++ b/fuzz/fuzz_targets/fuzz_compress.rs
@@ -5,13 +5,19 @@ use libfuzzer_sys::fuzz_target;
 fuzz_target!(|data: &[u8]| {
     let compressor = fsst::Compressor::train(&vec![data]);
     let compressed = compressor.compress(data);
-    let decompress = compressor.decompressor().decompress(&compressed);
-    assert_eq!(&decompress, data);
+    let decompressed = compressor.decompressor().decompress(&compressed);
+    assert_eq!(&decompressed, data);
 
     // Rebuild a compressor using the symbol table, and assert that it compresses and roundtrips
     // identically.
     let recompressor =
         fsst::Compressor::rebuild_from(compressor.symbol_table(), compressor.symbol_lengths());
     let recompressed = recompressor.compress(data);
-    assert_eq!(&compressed, &recompressed);
+    assert_eq!(
+        &compressed,
+        &recompressed,
+        "failed comparison with data {:?} symbols: {:?}",
+        data,
+        compressor.symbol_table(),
+    );
 });

--- a/fuzz/fuzz_targets/fuzz_compress.rs
+++ b/fuzz/fuzz_targets/fuzz_compress.rs
@@ -3,9 +3,15 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    let compressor =
-        fsst::Compressor::train(&vec![b"the quick brown fox jumped over the lazy dog"]);
-    let compress = compressor.compress(data);
-    let decompress = compressor.decompressor().decompress(&compress);
+    let compressor = fsst::Compressor::train(&vec![data]);
+    let compressed = compressor.compress(data);
+    let decompress = compressor.decompressor().decompress(&compressed);
     assert_eq!(&decompress, data);
+
+    // Rebuild a compressor using the symbol table, and assert that it compresses and roundtrips
+    // identically.
+    let recompressor =
+        fsst::Compressor::rebuild_from(compressor.symbol_table(), compressor.symbol_lengths());
+    let recompressed = recompressor.compress(data);
+    assert_eq!(&compressed, &recompressed);
 });

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-08-14"
+channel = "nightly-2025-02-24"
 components = ["rust-src", "rustfmt", "clippy"]
 profile = "minimal"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4,13 +4,12 @@
 //!
 //! [FSST Paper]: https://www.vldb.org/pvldb/vol13/p2649-boncz.pdf
 
-use std::cmp::Ordering;
-use std::collections::BinaryHeap;
-
 use crate::{
     advance_8byte_word, compare_masked, lossy_pht::LossyPHT, Code, Compressor, Symbol,
     FSST_CODE_BASE, FSST_CODE_MASK,
 };
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
 
 /// Bitmap that only works for values up to 512
 #[derive(Clone, Copy, Debug, Default)]
@@ -299,7 +298,104 @@ impl Default for CompressorBuilder {
     }
 }
 
+fn validate_symbol_order(symbol_lens: &[u8]) {
+    // Ensure that the symbol table is ordered by length, 23456781
+    let mut expected = 2;
+    for (idx, &len) in symbol_lens.iter().enumerate() {
+        if expected == 1 {
+            assert_eq!(
+                len, 1,
+                "symbol code={idx} should be one byte, was {len} bytes"
+            );
+        } else {
+            if len == 1 {
+                expected = 1;
+            }
+
+            // we're in the non-zero portion.
+            assert!(
+                len >= expected,
+                "symbol code={idx} breaks violates FSST symbol table ordering"
+            );
+            expected = len;
+        }
+    }
+}
+
 impl CompressorBuilder {
+    /// Rebuild a compressor from an existing symbol table.
+    ///
+    /// This will not attempt to optimize or re-order the codes.
+    pub fn rebuild_from(
+        symbols: impl AsRef<[Symbol]>,
+        symbol_lens: impl AsRef<[u8]>,
+    ) -> Compressor {
+        let symbols = symbols.as_ref();
+        let symbol_lens = symbol_lens.as_ref();
+
+        assert_eq!(
+            symbols.len(),
+            symbol_lens.len(),
+            "symbols and lengths differ"
+        );
+        assert!(symbols.len() <= 254, "symbol table len must be <= 254");
+        validate_symbol_order(symbol_lens);
+
+        // Insert the symbols in their given order into the FSST lookup structures.
+        let symbols = symbols.to_vec();
+        let lengths = symbol_lens.to_vec();
+        let mut lossy_pht = LossyPHT::new();
+
+        // Initialize the codes_two_byte table.
+        let mut codes_two_byte = Vec::with_capacity(65_535);
+        for tb in 0..=(255 * 255) {
+            codes_two_byte.push(Code::new_escape(tb as u8));
+        }
+
+        // Insert all of the one-byte symbols first.
+        for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
+            if len == 1 {
+                codes_two_byte[symbol.first_byte() as usize] = Code::new_symbol(code as u8, 1);
+            }
+        }
+
+        // Insert all of the two-byte symbols over the one-byte
+        for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
+            if len == 2 {
+                codes_two_byte[symbol.first2() as usize] = Code::new_symbol(code as u8, 2);
+            }
+        }
+
+        // Insert the 3+ byte symbols into the Lossy PHT
+        for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
+            if len >= 3 {
+                lossy_pht.insert(symbol, len as usize, code as u8);
+            }
+        }
+
+        // Find the position of the first code that has a suffix later in the table
+        let mut has_suffix_code = symbols.len() as u8;
+        for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
+            if len != 2 {
+                break;
+            }
+            let rest = &symbols[code..];
+            if rest.iter().any(|&other| symbol.first2() == other.first2()) {
+                has_suffix_code = code as u8;
+                break;
+            }
+        }
+
+        Compressor {
+            n_symbols: symbols.len() as u8,
+            symbols,
+            lengths,
+            codes_two_byte,
+            lossy_pht,
+            has_suffix_code,
+        }
+    }
+
     /// Attempt to insert a new symbol at the end of the table.
     ///
     /// # Panics
@@ -853,7 +949,8 @@ impl Ord for Candidate {
 
 #[cfg(test)]
 mod test {
-    use crate::{builder::CodesBitmap, Compressor, ESCAPE_CODE};
+    use crate::{builder::CodesBitmap, Compressor, CompressorBuilder, Symbol, ESCAPE_CODE};
+    use std::{iter, mem};
 
     #[test]
     fn test_builder() {
@@ -930,5 +1027,58 @@ mod test {
     fn test_bitmap_invalid() {
         let mut map = CodesBitmap::default();
         map.set(512);
+    }
+
+    #[test]
+    fn test_symbols_good() {
+        let symbols_u64: &[u64] = &[
+            24931, 25698, 25442, 25699, 25186, 25444, 24932, 25188, 25185, 25441, 25697, 25700,
+            24929, 24930, 25443, 25187, 6513249, 6512995, 6578786, 6513761, 6513507, 6382434,
+            6579042, 6512994, 6447460, 6447969, 6382178, 6579041, 6512993, 6448226, 6513250,
+            6579297, 6513506, 6447459, 6513764, 6447458, 6578529, 6382180, 6513762, 6447714,
+            6579299, 6513508, 6382436, 6513763, 6578532, 6381924, 6448228, 6579300, 6381921,
+            6382690, 6382179, 6447713, 6447972, 6513505, 6447457, 6382692, 6513252, 6578785,
+            6578787, 6578531, 6448225, 6382177, 6382433, 6578530, 6448227, 6381922, 6578788,
+            6579044, 6382691, 6512996, 6579043, 6579298, 6447970, 6447716, 6447971, 6381923,
+            6447715, 97, 98, 100, 99, 97, 98, 99, 100,
+        ];
+        let symbols: &[Symbol] = unsafe { mem::transmute(symbols_u64) };
+        let lens: Vec<u8> = iter::repeat_n(2u8, 16)
+            .chain(iter::repeat_n(3u8, 61))
+            .chain(iter::repeat_n(1u8, 8))
+            .collect();
+
+        let compressor = CompressorBuilder::rebuild_from(symbols, lens);
+        let built_symbols: &[u64] = unsafe { mem::transmute(compressor.symbol_table()) };
+        assert_eq!(built_symbols, symbols_u64);
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_symbols_bad() {
+        let symbols: &[u64] = &[
+            24931, 25698, 25442, 25699, 25186, 25444, 24932, 25188, 25185, 25441, 25697, 25700,
+            24929, 24930, 25443, 25187, 6513249, 6512995, 6578786, 6513761, 6513507, 6382434,
+            6579042, 6512994, 6447460, 6447969, 6382178, 6579041, 6512993, 6448226, 6513250,
+            6579297, 6513506, 6447459, 6513764, 6447458, 6578529, 6382180, 6513762, 6447714,
+            6579299, 6513508, 6382436, 6513763, 6578532, 6381924, 6448228, 6579300, 6381921,
+            6382690, 6382179, 6447713, 6447972, 6513505, 6447457, 6382692, 6513252, 6578785,
+            6578787, 6578531, 6448225, 6382177, 6382433, 6578530, 6448227, 6381922, 6578788,
+            6579044, 6382691, 6512996, 6579043, 6579298, 6447970, 6447716, 6447971, 6381923,
+            6447715, 97, 98, 100, 99, 97, 98, 99, 100,
+        ];
+        let lens: Vec<u8> = iter::repeat_n(2u8, 16)
+            .chain(iter::repeat_n(3u8, 61))
+            .chain(iter::repeat_n(1u8, 8))
+            .collect();
+
+        let mut builder = CompressorBuilder::new();
+        for (symbol, len) in symbols.iter().zip(lens.iter()) {
+            let symbol = Symbol::from_slice(&symbol.to_le_bytes());
+            builder.insert(symbol, *len as usize);
+        }
+        let compressor = builder.build();
+        let built_symbols: &[u64] = unsafe { std::mem::transmute(compressor.symbol_table()) };
+        assert_eq!(built_symbols, symbols);
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -282,10 +282,8 @@ impl CompressorBuilder {
         }
 
         // Fill codes_two_byte with pseudocode of first byte
-        for byte1 in 0..=255 {
-            for _byte2 in 0..=255 {
-                table.codes_two_byte.push(Code::new_escape(byte1));
-            }
+        for idx in 0..=65_535 {
+            table.codes_two_byte.push(Code::new_escape(idx as u8));
         }
 
         table
@@ -477,8 +475,7 @@ impl CompressorBuilder {
                 self.codes_two_byte[two_bytes] = Code::new_symbol(new_code, 2);
             } else {
                 // The one-byte code for the given code number here...
-                let new_code = self.codes_one_byte[two_bytes as u8 as usize];
-                self.codes_two_byte[two_bytes] = new_code;
+                self.codes_two_byte[two_bytes] = self.codes_one_byte[two_bytes & 0xFF];
             }
         }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,8 +5,8 @@
 //! [FSST Paper]: https://www.vldb.org/pvldb/vol13/p2649-boncz.pdf
 
 use crate::{
-    advance_8byte_word, compare_masked, lossy_pht::LossyPHT, Code, Compressor, Symbol,
-    FSST_CODE_BASE, FSST_CODE_MASK,
+    Code, Compressor, FSST_CODE_BASE, FSST_CODE_MASK, Symbol, advance_8byte_word, compare_masked,
+    lossy_pht::LossyPHT,
 };
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
@@ -72,7 +72,7 @@ struct CodesIterator<'a> {
     reference: usize,
 }
 
-impl<'a> Iterator for CodesIterator<'a> {
+impl Iterator for CodesIterator<'_> {
     type Item = u16;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -298,104 +298,7 @@ impl Default for CompressorBuilder {
     }
 }
 
-fn validate_symbol_order(symbol_lens: &[u8]) {
-    // Ensure that the symbol table is ordered by length, 23456781
-    let mut expected = 2;
-    for (idx, &len) in symbol_lens.iter().enumerate() {
-        if expected == 1 {
-            assert_eq!(
-                len, 1,
-                "symbol code={idx} should be one byte, was {len} bytes"
-            );
-        } else {
-            if len == 1 {
-                expected = 1;
-            }
-
-            // we're in the non-zero portion.
-            assert!(
-                len >= expected,
-                "symbol code={idx} breaks violates FSST symbol table ordering"
-            );
-            expected = len;
-        }
-    }
-}
-
 impl CompressorBuilder {
-    /// Rebuild a compressor from an existing symbol table.
-    ///
-    /// This will not attempt to optimize or re-order the codes.
-    pub fn rebuild_from(
-        symbols: impl AsRef<[Symbol]>,
-        symbol_lens: impl AsRef<[u8]>,
-    ) -> Compressor {
-        let symbols = symbols.as_ref();
-        let symbol_lens = symbol_lens.as_ref();
-
-        assert_eq!(
-            symbols.len(),
-            symbol_lens.len(),
-            "symbols and lengths differ"
-        );
-        assert!(symbols.len() <= 254, "symbol table len must be <= 254");
-        validate_symbol_order(symbol_lens);
-
-        // Insert the symbols in their given order into the FSST lookup structures.
-        let symbols = symbols.to_vec();
-        let lengths = symbol_lens.to_vec();
-        let mut lossy_pht = LossyPHT::new();
-
-        // Initialize the codes_two_byte table.
-        let mut codes_two_byte = Vec::with_capacity(65_535);
-        for tb in 0..=(255 * 255) {
-            codes_two_byte.push(Code::new_escape(tb as u8));
-        }
-
-        // Insert all of the one-byte symbols first.
-        for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
-            if len == 1 {
-                codes_two_byte[symbol.first_byte() as usize] = Code::new_symbol(code as u8, 1);
-            }
-        }
-
-        // Insert all of the two-byte symbols over the one-byte
-        for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
-            if len == 2 {
-                codes_two_byte[symbol.first2() as usize] = Code::new_symbol(code as u8, 2);
-            }
-        }
-
-        // Insert the 3+ byte symbols into the Lossy PHT
-        for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
-            if len >= 3 {
-                lossy_pht.insert(symbol, len as usize, code as u8);
-            }
-        }
-
-        // Find the position of the first code that has a suffix later in the table
-        let mut has_suffix_code = symbols.len() as u8;
-        for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
-            if len != 2 {
-                break;
-            }
-            let rest = &symbols[code..];
-            if rest.iter().any(|&other| symbol.first2() == other.first2()) {
-                has_suffix_code = code as u8;
-                break;
-            }
-        }
-
-        Compressor {
-            n_symbols: symbols.len() as u8,
-            symbols,
-            lengths,
-            codes_two_byte,
-            lossy_pht,
-            has_suffix_code,
-        }
-    }
-
     /// Attempt to insert a new symbol at the end of the table.
     ///
     /// # Panics
@@ -949,8 +852,7 @@ impl Ord for Candidate {
 
 #[cfg(test)]
 mod test {
-    use crate::{builder::CodesBitmap, Compressor, CompressorBuilder, Symbol, ESCAPE_CODE};
-    use std::{iter, mem};
+    use crate::{Compressor, ESCAPE_CODE, builder::CodesBitmap};
 
     #[test]
     fn test_builder() {
@@ -1027,58 +929,5 @@ mod test {
     fn test_bitmap_invalid() {
         let mut map = CodesBitmap::default();
         map.set(512);
-    }
-
-    #[test]
-    fn test_symbols_good() {
-        let symbols_u64: &[u64] = &[
-            24931, 25698, 25442, 25699, 25186, 25444, 24932, 25188, 25185, 25441, 25697, 25700,
-            24929, 24930, 25443, 25187, 6513249, 6512995, 6578786, 6513761, 6513507, 6382434,
-            6579042, 6512994, 6447460, 6447969, 6382178, 6579041, 6512993, 6448226, 6513250,
-            6579297, 6513506, 6447459, 6513764, 6447458, 6578529, 6382180, 6513762, 6447714,
-            6579299, 6513508, 6382436, 6513763, 6578532, 6381924, 6448228, 6579300, 6381921,
-            6382690, 6382179, 6447713, 6447972, 6513505, 6447457, 6382692, 6513252, 6578785,
-            6578787, 6578531, 6448225, 6382177, 6382433, 6578530, 6448227, 6381922, 6578788,
-            6579044, 6382691, 6512996, 6579043, 6579298, 6447970, 6447716, 6447971, 6381923,
-            6447715, 97, 98, 100, 99, 97, 98, 99, 100,
-        ];
-        let symbols: &[Symbol] = unsafe { mem::transmute(symbols_u64) };
-        let lens: Vec<u8> = iter::repeat_n(2u8, 16)
-            .chain(iter::repeat_n(3u8, 61))
-            .chain(iter::repeat_n(1u8, 8))
-            .collect();
-
-        let compressor = CompressorBuilder::rebuild_from(symbols, lens);
-        let built_symbols: &[u64] = unsafe { mem::transmute(compressor.symbol_table()) };
-        assert_eq!(built_symbols, symbols_u64);
-    }
-
-    #[should_panic]
-    #[test]
-    fn test_symbols_bad() {
-        let symbols: &[u64] = &[
-            24931, 25698, 25442, 25699, 25186, 25444, 24932, 25188, 25185, 25441, 25697, 25700,
-            24929, 24930, 25443, 25187, 6513249, 6512995, 6578786, 6513761, 6513507, 6382434,
-            6579042, 6512994, 6447460, 6447969, 6382178, 6579041, 6512993, 6448226, 6513250,
-            6579297, 6513506, 6447459, 6513764, 6447458, 6578529, 6382180, 6513762, 6447714,
-            6579299, 6513508, 6382436, 6513763, 6578532, 6381924, 6448228, 6579300, 6381921,
-            6382690, 6382179, 6447713, 6447972, 6513505, 6447457, 6382692, 6513252, 6578785,
-            6578787, 6578531, 6448225, 6382177, 6382433, 6578530, 6448227, 6381922, 6578788,
-            6579044, 6382691, 6512996, 6579043, 6579298, 6447970, 6447716, 6447971, 6381923,
-            6447715, 97, 98, 100, 99, 97, 98, 99, 100,
-        ];
-        let lens: Vec<u8> = iter::repeat_n(2u8, 16)
-            .chain(iter::repeat_n(3u8, 61))
-            .chain(iter::repeat_n(1u8, 8))
-            .collect();
-
-        let mut builder = CompressorBuilder::new();
-        for (symbol, len) in symbols.iter().zip(lens.iter()) {
-            let symbol = Symbol::from_slice(&symbol.to_le_bytes());
-            builder.insert(symbol, *len as usize);
-        }
-        let compressor = builder.build();
-        let built_symbols: &[u64] = unsafe { std::mem::transmute(compressor.symbol_table()) };
-        assert_eq!(built_symbols, symbols);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(iter_repeat_n)]
 #![doc = include_str!("../README.md")]
 #![cfg(target_endian = "little")]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -764,7 +764,11 @@ impl Compressor {
             symbol_lens.len(),
             "symbols and lengths differ"
         );
-        assert!(symbols.len() <= 254, "symbol table len must be <= 254");
+        assert!(
+            symbols.len() <= 255,
+            "symbol table len must be <= 255, was {}",
+            symbols.len()
+        );
         validate_symbol_order(symbol_lens);
 
         // Insert the symbols in their given order into the FSST lookup structures.
@@ -772,41 +776,56 @@ impl Compressor {
         let lengths = symbol_lens.to_vec();
         let mut lossy_pht = LossyPHT::new();
 
-        // Initialize the codes_two_byte table.
-        let mut codes_two_byte = Vec::with_capacity(65_535);
-        for tb in 0..=(255 * 255) {
-            codes_two_byte.push(Code::new_escape(tb as u8));
-        }
+        let mut codes_one_byte = vec![Code::UNUSED; 256];
 
-        // Insert all of the one-byte symbols first.
+        // Insert all of the one byte symbols first.
         for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
             if len == 1 {
-                codes_two_byte[symbol.first_byte() as usize] = Code::new_symbol(code as u8, 1);
+                codes_one_byte[symbol.first_byte() as usize] = Code::new_symbol(code as u8, 1);
             }
         }
 
-        // Insert all of the two-byte symbols over the one-byte
+        // Initialize the codes_two_byte table to be all escapes
+        let mut codes_two_byte = vec![Code::UNUSED; 65_536];
+
+        // Insert the two byte symbols, possibly overwriting slots for one-byte symbols and escapes.
         for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
-            if len == 2 {
-                codes_two_byte[symbol.first2() as usize] = Code::new_symbol(code as u8, 2);
+            match len {
+                2 => {
+                    codes_two_byte[symbol.first2() as usize] =
+                        Code::new_symbol_building(code as u8, 2);
+                }
+                3.. => {
+                    assert!(
+                        lossy_pht.insert(symbol, len as usize, code as u8),
+                        "rebuild symbol insertion into PHT must succeed"
+                    );
+                }
+                _ => { /* Covered by the 1-byte loop above. */ }
             }
         }
 
-        // Insert the 3+ byte symbols into the Lossy PHT
-        for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
-            if len >= 3 {
-                lossy_pht.insert(symbol, len as usize, code as u8);
+        // Build the finished codes_two_byte table, subbing in unused positions with the
+        // codes_one_byte value similar to what we do in CompressBuilder::finalize.
+        for (symbol, code) in codes_two_byte.iter_mut().enumerate() {
+            if *code == Code::UNUSED {
+                *code = codes_one_byte[symbol & 0xFF];
+            } else {
+                *code = Code::new_symbol(code.code(), 2);
             }
         }
 
-        // Find the position of the first code that has a suffix later in the table
+        // Find the position of the first 2-byte code that has a suffix later in the table
         let mut has_suffix_code = symbols.len() as u8;
         for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
             if len != 2 {
                 break;
             }
             let rest = &symbols[code..];
-            if rest.iter().any(|&other| symbol.first2() == other.first2()) {
+            if rest
+                .iter()
+                .any(|&other| other.len() > 2 && symbol.first2() == other.first2())
+            {
                 has_suffix_code = code as u8;
                 break;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(iter_repeat_n)]
+#![allow(unsafe_op_in_unsafe_fn)]
 #![doc = include_str!("../README.md")]
 #![cfg(target_endian = "little")]
 
@@ -63,11 +63,7 @@ impl Symbol {
         // Special case handling of a symbol with all-zeros. This is actually
         // a 1-byte symbol containing 0x00.
         let len = size_of::<Self>() - null_bytes;
-        if len == 0 {
-            1
-        } else {
-            len
-        }
+        if len == 0 { 1 } else { len }
     }
 
     #[inline]
@@ -705,7 +701,10 @@ impl Compressor {
         }
 
         // in_ptr should have exceeded in_end
-        assert!(in_ptr >= in_end, "exhausted output buffer before exhausting input, there is a bug in SymbolTable::compress()");
+        assert!(
+            in_ptr >= in_end,
+            "exhausted output buffer before exhausting input, there is a bug in SymbolTable::compress()"
+        );
 
         // Count the number of bytes written
         // SAFETY: assertion
@@ -752,6 +751,76 @@ impl Compressor {
     pub fn symbol_lengths(&self) -> &[u8] {
         &self.lengths[0..self.n_symbols as usize]
     }
+
+    /// Rebuild a compressor from an existing symbol table.
+    ///
+    /// This will not attempt to optimize or re-order the codes.
+    pub fn rebuild_from(symbols: impl AsRef<[Symbol]>, symbol_lens: impl AsRef<[u8]>) -> Self {
+        let symbols = symbols.as_ref();
+        let symbol_lens = symbol_lens.as_ref();
+
+        assert_eq!(
+            symbols.len(),
+            symbol_lens.len(),
+            "symbols and lengths differ"
+        );
+        assert!(symbols.len() <= 254, "symbol table len must be <= 254");
+        validate_symbol_order(symbol_lens);
+
+        // Insert the symbols in their given order into the FSST lookup structures.
+        let symbols = symbols.to_vec();
+        let lengths = symbol_lens.to_vec();
+        let mut lossy_pht = LossyPHT::new();
+
+        // Initialize the codes_two_byte table.
+        let mut codes_two_byte = Vec::with_capacity(65_535);
+        for tb in 0..=(255 * 255) {
+            codes_two_byte.push(Code::new_escape(tb as u8));
+        }
+
+        // Insert all of the one-byte symbols first.
+        for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
+            if len == 1 {
+                codes_two_byte[symbol.first_byte() as usize] = Code::new_symbol(code as u8, 1);
+            }
+        }
+
+        // Insert all of the two-byte symbols over the one-byte
+        for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
+            if len == 2 {
+                codes_two_byte[symbol.first2() as usize] = Code::new_symbol(code as u8, 2);
+            }
+        }
+
+        // Insert the 3+ byte symbols into the Lossy PHT
+        for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
+            if len >= 3 {
+                lossy_pht.insert(symbol, len as usize, code as u8);
+            }
+        }
+
+        // Find the position of the first code that has a suffix later in the table
+        let mut has_suffix_code = symbols.len() as u8;
+        for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
+            if len != 2 {
+                break;
+            }
+            let rest = &symbols[code..];
+            if rest.iter().any(|&other| symbol.first2() == other.first2()) {
+                has_suffix_code = code as u8;
+                break;
+            }
+        }
+
+        Compressor {
+            n_symbols: symbols.len() as u8,
+            symbols,
+            lengths,
+            codes_two_byte,
+            lossy_pht,
+            has_suffix_code,
+        }
+    }
 }
 
 #[inline]
@@ -761,10 +830,30 @@ pub(crate) fn advance_8byte_word(word: u64, bytes: usize) -> u64 {
     //
     // Note that even though this looks like it branches, Rust compiles this to a
     // conditional move instruction. See `<https://godbolt.org/z/Pbvre65Pq>`
-    if bytes == 8 {
-        0
-    } else {
-        word >> (8 * bytes)
+    if bytes == 8 { 0 } else { word >> (8 * bytes) }
+}
+
+fn validate_symbol_order(symbol_lens: &[u8]) {
+    // Ensure that the symbol table is ordered by length, 23456781
+    let mut expected = 2;
+    for (idx, &len) in symbol_lens.iter().enumerate() {
+        if expected == 1 {
+            assert_eq!(
+                len, 1,
+                "symbol code={idx} should be one byte, was {len} bytes"
+            );
+        } else {
+            if len == 1 {
+                expected = 1;
+            }
+
+            // we're in the non-zero portion.
+            assert!(
+                len >= expected,
+                "symbol code={idx} breaks violates FSST symbol table ordering"
+            );
+            expected = len;
+        }
     }
 }
 
@@ -777,6 +866,7 @@ pub(crate) fn compare_masked(left: u64, right: u64, ignored_bits: u16) -> bool {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::{iter, mem};
     #[test]
     fn test_stuff() {
         let compressor = {
@@ -793,5 +883,58 @@ mod test {
         assert_eq!(len, 8);
         unsafe { decompressed.set_len(len) };
         assert_eq!(&decompressed, "helloooo".as_bytes());
+    }
+
+    #[test]
+    fn test_symbols_good() {
+        let symbols_u64: &[u64] = &[
+            24931, 25698, 25442, 25699, 25186, 25444, 24932, 25188, 25185, 25441, 25697, 25700,
+            24929, 24930, 25443, 25187, 6513249, 6512995, 6578786, 6513761, 6513507, 6382434,
+            6579042, 6512994, 6447460, 6447969, 6382178, 6579041, 6512993, 6448226, 6513250,
+            6579297, 6513506, 6447459, 6513764, 6447458, 6578529, 6382180, 6513762, 6447714,
+            6579299, 6513508, 6382436, 6513763, 6578532, 6381924, 6448228, 6579300, 6381921,
+            6382690, 6382179, 6447713, 6447972, 6513505, 6447457, 6382692, 6513252, 6578785,
+            6578787, 6578531, 6448225, 6382177, 6382433, 6578530, 6448227, 6381922, 6578788,
+            6579044, 6382691, 6512996, 6579043, 6579298, 6447970, 6447716, 6447971, 6381923,
+            6447715, 97, 98, 100, 99, 97, 98, 99, 100,
+        ];
+        let symbols: &[Symbol] = unsafe { mem::transmute(symbols_u64) };
+        let lens: Vec<u8> = iter::repeat_n(2u8, 16)
+            .chain(iter::repeat_n(3u8, 61))
+            .chain(iter::repeat_n(1u8, 8))
+            .collect();
+
+        let compressor = Compressor::rebuild_from(symbols, lens);
+        let built_symbols: &[u64] = unsafe { mem::transmute(compressor.symbol_table()) };
+        assert_eq!(built_symbols, symbols_u64);
+    }
+
+    #[should_panic(expected = "assertion `left == right` failed")]
+    #[test]
+    fn test_symbols_bad() {
+        let symbols: &[u64] = &[
+            24931, 25698, 25442, 25699, 25186, 25444, 24932, 25188, 25185, 25441, 25697, 25700,
+            24929, 24930, 25443, 25187, 6513249, 6512995, 6578786, 6513761, 6513507, 6382434,
+            6579042, 6512994, 6447460, 6447969, 6382178, 6579041, 6512993, 6448226, 6513250,
+            6579297, 6513506, 6447459, 6513764, 6447458, 6578529, 6382180, 6513762, 6447714,
+            6579299, 6513508, 6382436, 6513763, 6578532, 6381924, 6448228, 6579300, 6381921,
+            6382690, 6382179, 6447713, 6447972, 6513505, 6447457, 6382692, 6513252, 6578785,
+            6578787, 6578531, 6448225, 6382177, 6382433, 6578530, 6448227, 6381922, 6578788,
+            6579044, 6382691, 6512996, 6579043, 6579298, 6447970, 6447716, 6447971, 6381923,
+            6447715, 97, 98, 100, 99, 97, 98, 99, 100,
+        ];
+        let lens: Vec<u8> = iter::repeat_n(2u8, 16)
+            .chain(iter::repeat_n(3u8, 61))
+            .chain(iter::repeat_n(1u8, 8))
+            .collect();
+
+        let mut builder = CompressorBuilder::new();
+        for (symbol, len) in symbols.iter().zip(lens.iter()) {
+            let symbol = Symbol::from_slice(&symbol.to_le_bytes());
+            builder.insert(symbol, *len as usize);
+        }
+        let compressor = builder.build();
+        let built_symbols: &[u64] = unsafe { mem::transmute(compressor.symbol_table()) };
+        assert_eq!(built_symbols, symbols);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(unsafe_op_in_unsafe_fn)]
 #![doc = include_str!("../README.md")]
 #![cfg(target_endian = "little")]
 
@@ -569,14 +568,16 @@ impl Compressor {
         //
         // SAFETY: caller ensures out_ptr is not null
         let first_byte = word as u8;
-        out_ptr.byte_add(1).write_unaligned(first_byte);
+        // SAFETY: out_ptr is not null
+        unsafe { out_ptr.byte_add(1).write_unaligned(first_byte) };
 
         // First, check the two_bytes table
         let code_twobyte = self.codes_two_byte[word as u16 as usize];
 
         if code_twobyte.code() < self.has_suffix_code {
             // 2 byte code without having to worry about longer matches.
-            std::ptr::write(out_ptr, code_twobyte.code());
+            // SAFETY: out_ptr is not null.
+            unsafe { std::ptr::write(out_ptr, code_twobyte.code()) };
 
             // Advance input by symbol length (2) and output by a single code byte
             (2, 1)
@@ -590,10 +591,12 @@ impl Compressor {
                 && compare_masked(word, entry.symbol.as_u64(), ignored_bits)
             {
                 // Advance the input by the symbol length (variable) and the output by one code byte
-                std::ptr::write(out_ptr, entry.code.code());
+                // SAFETY: out_ptr is not null.
+                unsafe { std::ptr::write(out_ptr, entry.code.code()) };
                 (entry.code.len() as usize, 1)
             } else {
-                std::ptr::write(out_ptr, code_twobyte.code());
+                // SAFETY: out_ptr is not null
+                unsafe { std::ptr::write(out_ptr, code_twobyte.code()) };
 
                 // Advance the input by the symbol length (variable) and the output by either 1
                 // byte (if was one-byte code) or two bytes (escape).
@@ -687,15 +690,19 @@ impl Compressor {
         // but shift data out of this word rather than advancing an input pointer and potentially reading
         // unowned memory.
         let mut bytes = [0u8; 8];
-        std::ptr::copy_nonoverlapping(in_ptr, bytes.as_mut_ptr(), remaining_bytes);
+        // SAFETY: remaining_bytes <= 8
+        unsafe { std::ptr::copy_nonoverlapping(in_ptr, bytes.as_mut_ptr(), remaining_bytes) };
         let mut last_word = u64::from_le_bytes(bytes);
 
         while in_ptr < in_end && out_ptr < out_end {
             // Load a full 8-byte word of data from in_ptr.
-            // SAFETY: caller asserts in_ptr is not null. we may read past end of pointer though.
-            let (advance_in, advance_out) = self.compress_word(last_word, out_ptr);
-            in_ptr = in_ptr.byte_add(advance_in);
-            out_ptr = out_ptr.byte_add(advance_out);
+            // SAFETY: caller asserts in_ptr is not null
+            let (advance_in, advance_out) = unsafe { self.compress_word(last_word, out_ptr) };
+            // SAFETY: pointer ranges are checked in the loop condition
+            unsafe {
+                in_ptr = in_ptr.add(advance_in);
+                out_ptr = out_ptr.add(advance_out);
+            }
 
             last_word = advance_8byte_word(last_word, advance_in);
         }
@@ -706,15 +713,17 @@ impl Compressor {
             "exhausted output buffer before exhausting input, there is a bug in SymbolTable::compress()"
         );
 
-        // Count the number of bytes written
-        // SAFETY: assertion
-        let bytes_written = out_ptr.offset_from(values.as_ptr());
+        assert!(out_ptr <= out_end, "output buffer sized too small");
+
+        // SAFETY: out_ptr is derived from the `values` allocation.
+        let bytes_written = unsafe { out_ptr.offset_from(values.as_ptr()) };
         assert!(
             bytes_written >= 0,
             "out_ptr ended before it started, not possible"
         );
 
-        values.set_len(bytes_written as usize);
+        // SAFETY: we have initialized `bytes_written` values in the output buffer.
+        unsafe { values.set_len(bytes_written as usize) };
     }
 
     /// Use the symbol table to compress the plaintext into a sequence of codes and escapes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -792,8 +792,7 @@ impl Compressor {
         for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
             match len {
                 2 => {
-                    codes_two_byte[symbol.first2() as usize] =
-                        Code::new_symbol_building(code as u8, 2);
+                    codes_two_byte[symbol.first2() as usize] = Code::new_symbol(code as u8, 2);
                 }
                 3.. => {
                     assert!(
@@ -810,13 +809,11 @@ impl Compressor {
         for (symbol, code) in codes_two_byte.iter_mut().enumerate() {
             if *code == Code::UNUSED {
                 *code = codes_one_byte[symbol & 0xFF];
-            } else {
-                *code = Code::new_symbol(code.code(), 2);
             }
         }
 
         // Find the position of the first 2-byte code that has a suffix later in the table
-        let mut has_suffix_code = symbols.len() as u8;
+        let mut has_suffix_code = 0u8;
         for (code, (&symbol, &len)) in symbols.iter().zip(lengths.iter()).enumerate() {
             if len != 2 {
                 break;

--- a/src/lossy_pht.rs
+++ b/src/lossy_pht.rs
@@ -1,8 +1,8 @@
 use std::fmt::Debug;
 
-use crate::builder::fsst_hash;
 use crate::Code;
 use crate::Symbol;
+use crate::builder::fsst_hash;
 
 /// Size of the perfect hash table.
 ///

--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -1,3 +1,5 @@
+//! Correctness tests for FSST.
+
 #![cfg(test)]
 
 use fsst::{Compressor, CompressorBuilder, Symbol};

--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -82,3 +82,24 @@ fn test_chinese() {
             .decompress(&trained.compress(ART_OF_WAR.as_bytes()))
     );
 }
+
+#[test]
+fn test_large_with_rebuild() {
+    let corpus: Vec<u8> = DECLARATION.bytes().cycle().take(10_240).collect();
+
+    let trained = Compressor::train(&vec![&corpus]);
+    let compressed = trained.compress(DECLARATION.as_bytes());
+
+    // let compressed = trained.compress(&massive);
+    let rebuilt = Compressor::rebuild_from(trained.symbol_table(), trained.symbol_lengths());
+    let recompressed = rebuilt.compress(DECLARATION.as_bytes());
+
+    assert_eq!(compressed, recompressed);
+
+    // Ensure round-trip after rebuilding the compressor
+    let decompressed = rebuilt.decompressor().decompress(&recompressed);
+    assert_eq!(
+        unsafe { std::str::from_utf8_unchecked(&decompressed) },
+        DECLARATION,
+    );
+}


### PR DESCRIPTION
It's useful to be able to rebuild a Compressor from an existing symbol table. For example, if you want to perform incremental compression, or compress a value to pushdown comparisons over the encoded data.

Going through `CompressorBuilder`, calling `insert` for each symbol and `build`ing may seem appropriate, but you're not guaranteed to get the same codes order afterward! This is because of the `finalize` step, many of the 2-byte codes will actually get reordered. This is an optimization we port from the C++ code, and allows us to skip a hashtable lookup during compression for many inputs.

To avoid the ambiguity, we provide a new `Compressor::rebuild_from` to rebuild from a slice of symbols and lens. This repopulates the `codes_two_byte` and hash table that are needed at compress time, and does so without the finalize step that occurs when going through the CompressorBuilder.

I've also gone and updated the fuzzer to check both a freshly built and a rebuilt compressor. It caught several bugs as I was going through cleaning up this PR 😅 I let the fuzzer run for 30 minutes on my laptop and it didn't find anything.