### PR TITLE
ci: move to Rust 1.85.0 stable toolchain

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -21,7 +21,7 @@ runs:
       with:
         toolchain: "${{ steps.rust-version.outputs.version }}"
         targets: "${{inputs.targets || ''}}"
-        components: clippy, rustfmt, miri, llvm-tools-preview
+        components: clippy, rustfmt
 
     - name: Rust Dependency Cache
       uses: Swatinem/rust-cache@v2

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -19,34 +19,10 @@ jobs:
       MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-backtrace=full
     steps:
       - uses: actions/checkout@v4
-
-      - name: Rust Version
-        id: rust-version
-        shell: bash
-        run: echo "version=$(cat rust-toolchain.toml | grep channel | awk -F'\"' '{print $2}')" >> $GITHUB_OUTPUT
-
-      - name: Rust Toolchain
-        id: rust-toolchain
-        uses: dtolnay/rust-toolchain@master
-        if: steps.rustup-cache.outputs.cache-hit != 'true'
-        with:
-          toolchain: "${{ steps.rust-version.outputs.version }}"
-          components: miri
-
-      - name: Rust Dependency Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/develop' }}
-          shared-key: "shared" # To allow reuse across jobs
-
-      - name: Rust Compile Cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-      - name: Rust Compile Cache Config
-        shell: bash
+      - name: Run miri with nightly toolchain
         run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
+          rustup toolchain install nightly --component miri
+          rustup override set nightly
+          cargo miri setup
+          cargo miri test
 
-      - name: Run tests with Miri
-        run: cargo miri test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ description = "Pure-Rust implementation of Fast Static Symbol Tables algorithm f
 authors = ["SpiralDB Developers <hello@spiraldb.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/spiraldb/fsst"
+rust-version = "1.85.0"
 edition = "2024"
 
 [lib]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-02-24"
+channel = "1.85.0"
 components = ["rust-src", "rustfmt", "clippy"]
 profile = "minimal"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -39,11 +39,11 @@ impl CodesBitmap {
         );
 
         let map = index >> 6;
-        self.codes[map] & 1 << (index % 64) != 0
+        self.codes[map] & (1 << (index % 64)) != 0
     }
 
     /// Get all codes set in this bitmap
-    pub(crate) fn codes(&self) -> CodesIterator {
+    pub(crate) fn codes(&self) -> CodesIterator<'_> {
         CodesIterator {
             inner: self,
             index: 0,
@@ -198,7 +198,7 @@ impl Counter {
 
     /// Returns an ordered iterator over the codes that were observed
     /// in a call to [`Self::count1`].
-    fn first_codes(&self) -> CodesIterator {
+    fn first_codes(&self) -> CodesIterator<'_> {
         self.code1_index.codes()
     }
 
@@ -207,7 +207,7 @@ impl Counter {
     ///
     /// This is the set of all values `code2` where there was
     /// previously a call to `self.record_count2(code1, code2)`.
-    fn second_codes(&self, code1: u16) -> CodesIterator {
+    fn second_codes(&self, code1: u16) -> CodesIterator<'_> {
         self.pair_index[code1 as usize].codes()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -742,7 +742,7 @@ impl Compressor {
 
     /// Access the decompressor that can be used to decompress strings emitted from this
     /// `Compressor` instance.
-    pub fn decompressor(&self) -> Decompressor {
+    pub fn decompressor(&self) -> Decompressor<'_> {
         Decompressor::new(self.symbol_table(), self.symbol_lengths())
     }
 


### PR DESCRIPTION
Use a stable toolchain for builds, still use nightly toolchain for miri.

We also set the MSRV explicitly to 1.85.0 so we can use 2024 edition