### PR TITLE
Perf experiments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,124 +344,25 @@ impl<'a> Decompressor<'a> {
                         // Otherwise, find the first escape code and write the symbols up to that point.
                         let first_escape_pos = escape_mask.trailing_zeros() >> 3; // Divide bits to bytes
                         debug_assert!(first_escape_pos < 8);
-                        match first_escape_pos {
-                            7 => {
-                                let code = (next_block & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 8) & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 16) & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 24) & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 32) & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 40) & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 48) & 0xFF) as u8;
-                                store_next_symbol!(code);
 
-                                in_ptr = in_ptr.add(7);
-                            }
-                            6 => {
-                                let code = (next_block & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 8) & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 16) & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 24) & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 32) & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 40) & 0xFF) as u8;
-                                store_next_symbol!(code);
+                        // Process all symbols before the escape position
+                        for i in 0..first_escape_pos {
+                            let code = ((next_block >> (i * 8)) & 0xFF) as u8;
+                            store_next_symbol!(code);
+                        }
 
-                                let escaped = ((next_block >> 56) & 0xFF) as u8;
-                                out_ptr.write(escaped);
-                                out_ptr = out_ptr.add(1);
-
-                                in_ptr = in_ptr.add(8);
-                            }
-                            5 => {
-                                let code = (next_block & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 8) & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 16) & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 24) & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 32) & 0xFF) as u8;
-                                store_next_symbol!(code);
-
-                                let escaped = ((next_block >> 48) & 0xFF) as u8;
-                                out_ptr.write(escaped);
-                                out_ptr = out_ptr.add(1);
-
-                                in_ptr = in_ptr.add(7);
-                            }
-                            4 => {
-                                let code = (next_block & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 8) & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 16) & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 24) & 0xFF) as u8;
-                                store_next_symbol!(code);
-
-                                let escaped = ((next_block >> 40) & 0xFF) as u8;
-                                out_ptr.write(escaped);
-                                out_ptr = out_ptr.add(1);
-
-                                in_ptr = in_ptr.add(6);
-                            }
-                            3 => {
-                                let code = (next_block & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 8) & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 16) & 0xFF) as u8;
-                                store_next_symbol!(code);
-
-                                let escaped = ((next_block >> 32) & 0xFF) as u8;
-                                out_ptr.write(escaped);
-                                out_ptr = out_ptr.add(1);
-
-                                in_ptr = in_ptr.add(5);
-                            }
-                            2 => {
-                                let code = (next_block & 0xFF) as u8;
-                                store_next_symbol!(code);
-                                let code = ((next_block >> 8) & 0xFF) as u8;
-                                store_next_symbol!(code);
-
-                                let escaped = ((next_block >> 24) & 0xFF) as u8;
-                                out_ptr.write(escaped);
-                                out_ptr = out_ptr.add(1);
-
-                                in_ptr = in_ptr.add(4);
-                            }
-                            1 => {
-                                let code = (next_block & 0xFF) as u8;
-                                store_next_symbol!(code);
-
-                                let escaped = ((next_block >> 16) & 0xFF) as u8;
-                                out_ptr.write(escaped);
-                                out_ptr = out_ptr.add(1);
-
-                                in_ptr = in_ptr.add(3);
-                            }
-                            0 => {
-                                // Otherwise, we actually need to decompress the next byte
-                                // Extract the second byte from the u32
-                                let escaped = ((next_block >> 8) & 0xFF) as u8;
-                                in_ptr = in_ptr.add(2);
-                                out_ptr.write(escaped);
-                                out_ptr = out_ptr.add(1);
-                            }
-                            _ => unreachable!(),
+                        // Handle the escaped byte
+                        if first_escape_pos < 7 {
+                            // The escaped byte is in the current block at position (first_escape_pos + 1) * 8 bits
+                            let escaped_byte_pos = (first_escape_pos + 1) * 8;
+                            let escaped = ((next_block >> escaped_byte_pos) & 0xFF) as u8;
+                            out_ptr.write(escaped);
+                            out_ptr = out_ptr.add(1);
+                            // Advance input pointer past the escape code and escaped byte
+                            in_ptr = in_ptr.add(first_escape_pos as usize + 2);
+                        } else {
+                            // Escape is at position 7, so we just advance past the symbols
+                            in_ptr = in_ptr.add(7);
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,6 +308,20 @@ impl<'a> Decompressor<'a> {
                 }};
             }
 
+            // Prefetch helper for symbol table entries
+            #[cfg(target_arch = "x86_64")]
+            #[inline(always)]
+            unsafe fn prefetch_symbol(ptr: *const Symbol) {
+                use std::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+                unsafe { _mm_prefetch(ptr as *const i8, _MM_HINT_T0) };
+            }
+
+            #[cfg(not(target_arch = "x86_64"))]
+            #[inline(always)]
+            unsafe fn prefetch_symbol(_ptr: *const Symbol) {
+                // No-op on non-x86_64 platforms
+            }
+
             // First we try loading 8 bytes at a time.
             if decoded.len() >= 8 * size_of::<Symbol>() && compressed.len() >= 8 {
                 // Extract the loop condition since the compiler fails to do so
@@ -321,8 +335,26 @@ impl<'a> Decompressor<'a> {
                         & ((((!next_block) & 0x7F7F7F7F7F7F7F7F) + 0x7F7F7F7F7F7F7F7F)
                             ^ 0x8080808080808080);
 
+                    // Prefetch symbols from the next block while processing current
+                    if in_ptr.add(8) < block_in_end {
+                        let future_block = in_ptr.add(8).cast::<u64>().read_unaligned();
+                        // Prefetch up to 4 symbols from the future block
+                        let symbol_base = self.symbols.as_ptr();
+                        prefetch_symbol(symbol_base.add((future_block & 0xFF) as usize));
+                        prefetch_symbol(symbol_base.add(((future_block >> 8) & 0xFF) as usize));
+                        prefetch_symbol(symbol_base.add(((future_block >> 16) & 0xFF) as usize));
+                        prefetch_symbol(symbol_base.add(((future_block >> 24) & 0xFF) as usize));
+                    }
+
                     // If there are no escape codes, we write each symbol one by one.
                     if escape_mask == 0 {
+                        // Prefetch all 8 symbols from current block for better cache locality
+                        let symbol_base = self.symbols.as_ptr();
+                        prefetch_symbol(symbol_base.add(((next_block >> 32) & 0xFF) as usize));
+                        prefetch_symbol(symbol_base.add(((next_block >> 40) & 0xFF) as usize));
+                        prefetch_symbol(symbol_base.add(((next_block >> 48) & 0xFF) as usize));
+                        prefetch_symbol(symbol_base.add(((next_block >> 56) & 0xFF) as usize));
+
                         let code = (next_block & 0xFF) as u8;
                         store_next_symbol!(code);
                         let code = ((next_block >> 8) & 0xFF) as u8;


### PR DESCRIPTION
Trying out some vibe-based perf.

The first commit here made this effect locally (removed compression benchmarks):
```
dbtext/wikipedia/decompress
                        time:   [887.44 µs 899.12 µs 911.18 µs]
                        thrpt:  [2.9261 GiB/s 2.9654 GiB/s 3.0044 GiB/s]
                 change:
                        time:   [-11.234% -10.036% -8.7806%] (p = 0.00 < 0.05)
                        thrpt:  [+9.6258% +11.156% +12.656%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

dbtext/l_comment/decompress
                        time:   [410.96 µs 414.94 µs 418.83 µs]
                        thrpt:  [6.1060 GiB/s 6.1632 GiB/s 6.2228 GiB/s]
                 change:
                        time:   [-1.0256% +0.1567% +1.4423%] (p = 0.80 > 0.05)
                        thrpt:  [-1.4218% -0.1564% +1.0362%]
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

dbtext/urls/decompress  time:   [1.1473 ms 1.1569 ms 1.1675 ms]
                        thrpt:  [5.0477 GiB/s 5.0940 GiB/s 5.1368 GiB/s]
                 change:
                        time:   [+0.5443% +1.9998% +3.5034%] (p = 0.01 < 0.05)
                        thrpt:  [-3.3848% -1.9606% -0.5414%]
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
```

Second one is more x86 oriented, so I'm going to let codspeed take a look at it.