### PR TITLE
fix: Handle exactly-sized buffers in `compress_into`/`decompress_into`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,17 +468,51 @@ impl<'a> Decompressor<'a> {
                 }
             }
 
-            // Otherwise, fall back to 1-byte reads.
-            while out_end.offset_from(out_ptr) > size_of::<Symbol>() as isize && in_ptr < in_end {
+            // Otherwise, fall back to 1-byte reads using 8-byte writes where safe.
+            while out_end.offset_from(out_ptr) >= size_of::<Symbol>() as isize && in_ptr < in_end {
                 let code = in_ptr.read();
                 in_ptr = in_ptr.add(1);
 
                 if code == ESCAPE_CODE {
+                    assert!(
+                        in_ptr < in_end,
+                        "truncated compressed string: escape code at end of input"
+                    );
                     out_ptr.write(in_ptr.read());
                     in_ptr = in_ptr.add(1);
                     out_ptr = out_ptr.add(1);
                 } else {
                     store_next_symbol!(code);
+                }
+            }
+
+            // For the last few bytes (if any) where we can't do an 8-byte unaligned write.
+            while in_ptr < in_end {
+                let code = in_ptr.read();
+                in_ptr = in_ptr.add(1);
+
+                if code == ESCAPE_CODE {
+                    assert!(
+                        in_ptr < in_end,
+                        "truncated compressed string: escape code at end of input"
+                    );
+                    assert!(
+                        out_ptr.cast_const() < out_end,
+                        "output buffer sized too small"
+                    );
+                    out_ptr.write(in_ptr.read());
+                    in_ptr = in_ptr.add(1);
+                    out_ptr = out_ptr.add(1);
+                } else {
+                    let len = *self.lengths.get_unchecked(code as usize) as usize;
+                    assert!(
+                        out_end.offset_from(out_ptr) >= len as isize,
+                        "output buffer sized too small"
+                    );
+                    let sym = self.symbols.get_unchecked(code as usize).to_u64();
+                    let sym_bytes = sym.to_le_bytes();
+                    std::ptr::copy_nonoverlapping(sym_bytes.as_ptr(), out_ptr, len);
+                    out_ptr = out_ptr.add(len);
                 }
             }
 
@@ -667,7 +701,7 @@ impl Compressor {
         // SAFETY: `end` will point just after the end of the `values` allocation.
         let out_end = unsafe { out_ptr.byte_add(values.capacity()) };
 
-        while (in_ptr as usize) <= in_end_sub8 && out_ptr < out_end {
+        while (in_ptr as usize) <= in_end_sub8 && unsafe { out_end.offset_from(out_ptr) } >= 2 {
             // SAFETY: pointer ranges are checked in the loop condition
             unsafe {
                 // Load a full 8-byte word of data from in_ptr.
@@ -695,7 +729,7 @@ impl Compressor {
         unsafe { std::ptr::copy_nonoverlapping(in_ptr, bytes.as_mut_ptr(), remaining_bytes) };
         let mut last_word = u64::from_le_bytes(bytes);
 
-        while in_ptr < in_end && out_ptr < out_end {
+        while in_ptr < in_end && unsafe { out_end.offset_from(out_ptr) } >= 2 {
             // Load a full 8-byte word of data from in_ptr.
             // SAFETY: caller asserts in_ptr is not null
             let (advance_in, advance_out) = unsafe { self.compress_word(last_word, out_ptr) };

--- a/tests/exact_capacity.rs
+++ b/tests/exact_capacity.rs
@@ -1,5 +1,7 @@
 //! Test to demonstrate successful decompression on exact capacity bounds without panicking
 
+#![cfg(test)]
+
 use fsst::{CompressorBuilder, Symbol};
 
 #[test]

--- a/tests/exact_capacity.rs
+++ b/tests/exact_capacity.rs
@@ -1,0 +1,37 @@
+//! Test to demonstrate successful decompression on exact capacity bounds without panicking
+
+use fsst::{CompressorBuilder, Symbol};
+
+#[test]
+fn test_decompress_exact_capacity() {
+    // Train a compressor with a symbol that expands significantly
+    let compressor = {
+        let mut builder = CompressorBuilder::new();
+        // Insert a highly compressible 8-byte symbol
+        builder.insert(Symbol::from_slice(b"aaaaaaaa"), 8);
+        builder.build()
+    };
+
+    // Create a large, highly compressible string
+    let plaintext = vec![b'a'; 100_000];
+
+    // Compress it into an over-allocated buffer to avoid any compression bugs
+    let mut compressed = Vec::with_capacity(plaintext.len() * 2);
+    unsafe {
+        compressor.compress_into(&plaintext, &mut compressed);
+    }
+
+    let decompressor = compressor.decompressor();
+
+    // If the caller allocates EXACTLY the uncompressed length (which is theoretically
+    // sufficient and correct), `decompress_into` should successfully decode the entire
+    // stream using the safe byte-by-byte fallback loop without early termination.
+    let mut decompressed = Vec::with_capacity(plaintext.len());
+    let spare = decompressed.spare_capacity_mut();
+
+    // This previously panicked with `exhaust input before output`. It should now succeed.
+    let len = decompressor.decompress_into(&compressed, spare);
+    unsafe { decompressed.set_len(len) };
+
+    assert_eq!(decompressed, plaintext);
+}


### PR DESCRIPTION
This PR addresses two buffer boundary bugs within the `compress_into` and `decompress_into` APIs.

* `decompress_into` - Utilized a fallback loop (`while out_end.offset_from(out_ptr) > 8`) to decode trailing bytes. If a caller provided exactly the uncompressed string's length as the target capacity, the loop would terminate prematurely if there were `< 8` bytes of remaining capacity. This resulted in an `assertion 'left == right' failed: decompression should exhaust input before output` panic.
* `compress_into` - Iterated over the input relying on `while out_ptr < out_end`. However, `compress_word` can emit an `ESCAPE_CODE` followed by a literal byte, which advances `out_ptr` by `2`. If `out_ptr` was at `out_end - 1`, the loop condition evaluated to `true`, but the second byte write would overwrite unowned memory past the allocation boundary.

Added a test for exactly-sized buffers in `tests/exact_capacity.rs`.