### PR TITLE
no more duplicate candidate generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +299,16 @@ version = "0.5.6"
 dependencies = [
  "codspeed-criterion-compat",
  "curl",
+ "fxhash",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ tests_outside_test_module = { level = "deny" }
 unwrap_in_result = { level = "deny" }
 use_debug = { level = "deny" }
 
+[dependencies]
+fxhash = "0.2"
+
 [dev-dependencies]
 criterion = { package = "codspeed-criterion-compat", version = "4.0" }
 curl = "0.4"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -8,8 +8,9 @@ use crate::{
     Code, Compressor, FSST_CODE_BASE, FSST_CODE_MASK, Symbol, advance_8byte_word, compare_masked,
     lossy_pht::LossyPHT,
 };
+use fxhash::FxHashMap;
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::BinaryHeap;
 
 /// Bitmap that only works for values up to 512
 #[derive(Clone, Copy, Debug, Default)]
@@ -760,7 +761,8 @@ impl CompressorBuilder {
         // Use a HashMap to deduplicate candidates by symbol content, combining gains
         // when the same symbol is encountered via different codes.
         // This matches the C++ implementation's use of unordered_set<QSymbol> with addOrInc.
-        let mut candidates: HashMap<Symbol, usize> = HashMap::new();
+        // NOTE: we use fxhash since that is the best Rust hasher for 64-bit ints.
+        let mut candidates = FxHashMap::default();
 
         for code1 in counters.first_codes() {
             let symbol1 = self.symbols[code1 as usize];

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -9,7 +9,7 @@ use crate::{
     lossy_pht::LossyPHT,
 };
 use std::cmp::Ordering;
-use std::collections::BinaryHeap;
+use std::collections::{BinaryHeap, HashMap};
 
 /// Bitmap that only works for values up to 512
 #[derive(Clone, Copy, Debug, Default)]
@@ -757,6 +757,11 @@ impl CompressorBuilder {
         sample_frac: usize,
         pqueue: &mut BinaryHeap<Candidate>,
     ) {
+        // Use a HashMap to deduplicate candidates by symbol content, combining gains
+        // when the same symbol is encountered via different codes.
+        // This matches the C++ implementation's use of unordered_set<QSymbol> with addOrInc.
+        let mut candidates: HashMap<Symbol, usize> = HashMap::new();
+
         for code1 in counters.first_codes() {
             let symbol1 = self.symbols[code1 as usize];
             let symbol1_len = symbol1.len();
@@ -771,14 +776,12 @@ impl CompressorBuilder {
             let mut gain = count * symbol1_len;
             // NOTE: use heuristic from C++ implementation to boost the gain of single-byte symbols.
             // This helps to reduce exception counts.
-            if code1 < 256 {
+            if symbol1_len == 1 {
                 gain *= 8;
             }
 
-            pqueue.push(Candidate {
-                symbol: symbol1,
-                gain,
-            });
+            // Add or combine gain for this symbol
+            *candidates.entry(symbol1).or_insert(0) += gain;
 
             // Skip merges on last round, or when symbol cannot be extended.
             if sample_frac >= 128 || symbol1_len == 8 {
@@ -795,11 +798,14 @@ impl CompressorBuilder {
                 let new_symbol = symbol1.concat(symbol2);
                 let gain = counters.count2(code1, code2) * new_symbol.len();
 
-                pqueue.push(Candidate {
-                    symbol: new_symbol,
-                    gain,
-                })
+                // Add or combine gain for this merged symbol
+                *candidates.entry(new_symbol).or_insert(0) += gain;
             }
+        }
+
+        // Transfer deduplicated candidates to the priority queue
+        for (symbol, gain) in candidates {
+            pqueue.push(Candidate { symbol, gain });
         }
 
         // clear self in advance of inserting the symbols.
@@ -933,5 +939,48 @@ mod test {
     fn test_bitmap_invalid() {
         let mut map = CodesBitmap::default();
         map.set(512);
+    }
+
+    #[test]
+    fn test_no_duplicate_symbols() {
+        // Train on data that is likely to produce duplicate 1-byte and 2-byte candidates.
+        let text = b"aababcabcdabcde";
+        let corpus: Vec<&[u8]> = std::iter::repeat_n(text.as_slice(), 100).collect();
+        let compressor = Compressor::train(&corpus);
+
+        let symbols = compressor.symbol_table();
+        let lengths = compressor.symbol_lengths();
+
+        // Collect all 1-byte symbols and check for duplicates.
+        let one_byte: Vec<u8> = symbols
+            .iter()
+            .zip(lengths.iter())
+            .filter(|&(_, &len)| len == 1)
+            .map(|(sym, _)| sym.first_byte())
+            .collect();
+        let mut one_byte_sorted = one_byte.clone();
+        one_byte_sorted.sort();
+        one_byte_sorted.dedup();
+        assert_eq!(
+            one_byte.len(),
+            one_byte_sorted.len(),
+            "duplicate 1-byte symbols found"
+        );
+
+        // Collect all 2-byte symbols and check for duplicates.
+        let two_byte: Vec<u16> = symbols
+            .iter()
+            .zip(lengths.iter())
+            .filter(|&(_, &len)| len == 2)
+            .map(|(sym, _)| sym.first2())
+            .collect();
+        let mut two_byte_sorted = two_byte.clone();
+        two_byte_sorted.sort();
+        two_byte_sorted.dedup();
+        assert_eq!(
+            two_byte.len(),
+            two_byte_sorted.len(),
+            "duplicate 2-byte symbols found"
+        );
     }
 }


### PR DESCRIPTION
Gave Claude access to our impl and the CWI implementation and it was able to track down why we have been seeing duplicate symbols:

>  Problem Analysis
>
>  The duplicate one-byte symbols occurred because of a mismatch between the C++ and Rust implementations:
>
>  1. C++ uses unordered_set<QSymbol> with addOrInc: This automatically deduplicates symbols by their content. When the same symbol is encountered via different
>   code paths, their gains are combined.
>  2. Rust was using BinaryHeap<Candidate> directly: This doesn't deduplicate, so the same symbol (e.g., 'h') could be pushed multiple times via different
>  codes:
>    - Code 104: escape symbol 'h' at symbols[104]
>    - Code 256+N: trained symbol 'h' at symbols[256+N]

>
>  The Fix
>
>  Two changes in builder.rs:754-816:
>
>  1. Added HashMap<Symbol, usize> for deduplication: Before pushing to the priority queue, candidates are collected in a HashMap keyed by Symbol. When the same
>   symbol appears multiple times, gains are combined with *candidates.entry(symbol).or_insert(0) += gain.
>  2. Fixed the 8x gain heuristic: Changed from if code1 < 256 to if symbol1_len == 1. The original code was checking the code index (escape codes are < 256),
>  but this didn't correctly identify one-byte symbols that were trained (which have codes ≥ 256). The C++ implementation uses s1.length()==1, so checking
>  symbol length is correct.
