### PR TITLE
Batch all-escaped blocks

### DIFF
--- a/benches/micro.rs
+++ b/benches/micro.rs
@@ -204,6 +204,24 @@ fn bench_compress(c: &mut Criterion) {
     });
     group.finish();
 
+    let mut group = c.benchmark_group("all-escape");
+    let test_string = one_megabyte(b"abcdefgh");
+    group.throughput(Throughput::Bytes(test_string.len() as u64));
+    // Empty symbol table: every byte becomes ESCAPE + raw byte.
+    let escape_compressor = CompressorBuilder::new().build();
+    group.bench_function("compress", |b| {
+        b.iter(|| unsafe {
+            escape_compressor.compress_into(&test_string, &mut output_buf);
+        })
+    });
+
+    let compressed_escape = escape_compressor.compress(&test_string);
+    let escape_decompressor = escape_compressor.decompressor();
+    group.bench_function("decompress", |b| {
+        b.iter(|| escape_decompressor.decompress(&compressed_escape))
+    });
+    group.finish();
+
     let _ = std::hint::black_box(output_buf);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,6 +341,15 @@ impl<'a> Decompressor<'a> {
                         let code = ((next_block >> 56) & 0xFF) as u8;
                         store_next_symbol!(code);
                         in_ptr = in_ptr.add(8);
+                    } else if (next_block & 0x00FF00FF00FF00FF) == 0x00FF00FF00FF00FF {
+                        // All 4 even-positioned bytes are ESCAPE_CODE.
+                        // Batch-extract the 4 raw bytes at odd positions.
+                        out_ptr.write(((next_block >> 8) & 0xFF) as u8);
+                        out_ptr.add(1).write(((next_block >> 24) & 0xFF) as u8);
+                        out_ptr.add(2).write(((next_block >> 40) & 0xFF) as u8);
+                        out_ptr.add(3).write(((next_block >> 56) & 0xFF) as u8);
+                        out_ptr = out_ptr.add(4);
+                        in_ptr = in_ptr.add(8);
                     } else {
                         // Otherwise, find the first escape code and write the symbols up to that point.
                         let first_escape_pos = escape_mask.trailing_zeros() >> 3; // Divide bits to bytes

--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -84,6 +84,20 @@ fn test_chinese() {
 }
 
 #[test]
+fn test_all_escape_roundtrip() {
+    // Empty symbol table: every byte is encoded as ESCAPE + raw byte.
+    let compressor = CompressorBuilder::new().build();
+    let decompressor = compressor.decompressor();
+
+    // Large enough to exercise the 8-byte block loop in decompress_into.
+    let input: Vec<u8> = (0..=255u8).cycle().take(4096).collect();
+    let compressed = compressor.compress(&input);
+    // All-escape compressed size should be exactly 2x input.
+    assert_eq!(compressed.len(), input.len() * 2);
+    assert_eq!(decompressor.decompress(&compressed), input);
+}
+
+#[test]
 fn test_large_with_rebuild() {
     let corpus: Vec<u8> = DECLARATION.bytes().cycle().take(10_240).collect();
 


### PR DESCRIPTION
The impact on this new benchmark compared to `develop` (running locally) is:
```
all-escape/decompress   time:   [250.45 µs 286.52 µs 322.61 µs]
                        thrpt:  [3.0271 GiB/s 3.4083 GiB/s 3.8992 GiB/s]
                 change:
                        time:   [-85.698% -84.777% -83.554%] (p = 0.00 < 0.05)
                        thrpt:  [+508.06% +556.89% +599.20%]
                        Performance has improved.
```