### PR TITLE
bump toolchain to 1.94.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,21 @@ jobs:
       - name: Rust Test
         run: cargo test --workspace --all-features
 
+  msrv:
+    name: MSRV Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Get MSRV
+        id: msrv
+        run: echo "version=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[0].rust_version')" >> $GITHUB_OUTPUT
+      - name: Install MSRV Toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "${{ steps.msrv.outputs.version }}"
+      - name: Rust Build
+        run: cargo build --all-features --all-targets
+
   bench-codspeed:
     name: Benchmark with Codspeed
     runs-on: ubuntu-latest

--- a/benches/compress.rs
+++ b/benches/compress.rs
@@ -1,7 +1,7 @@
 //! Benchmarks for FSST compression, decompression, and symbol table training.
 //!
 //! We use the dbtext data at https://github.com/cwida/fsst/tree/master/paper/dbtext
-#![allow(missing_docs)]
+#![allow(missing_docs, clippy::unwrap_in_result)]
 use core::str;
 use std::{
     error::Error,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.94.0"
 components = ["rust-src", "rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
1.86.0 is too old for cargo-edit. We leave MSRV but bump the dev toolchain to latest stable.