### PR TITLE
allow dirty workstate for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           cargo set-version ${{ github.event.release.tag_name }}
       - name: Release
-        run: cargo publish
+        run: cargo publish --allow-dirty
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Required because cargo edit gets run.