### PR TITLE
feat: prune low-value symbols from table on small inputs

### DIFF
--- a/benches/compress.rs
+++ b/benches/compress.rs
@@ -70,11 +70,11 @@ fn run_bench(name: &str, buf: &[u8], c: &mut Criterion) {
     let mut buffer = Vec::with_capacity(buf.len() * 2);
     group.throughput(Throughput::Bytes(buf.len() as u64));
     group.bench_function("compress-only", |b| {
-        b.iter(|| unsafe { compressor.compress_into(&buf, &mut buffer) });
+        b.iter(|| unsafe { compressor.compress_into(buf, &mut buffer) });
     });
 
     unsafe {
-        compressor.compress_into(&buf, &mut buffer);
+        compressor.compress_into(buf, &mut buffer);
     };
     let decompressor = compressor.decompressor();
     group.bench_function("decompress", |b| {
@@ -129,11 +129,10 @@ fn bench_dbtext(c: &mut Criterion) {
 }
 
 /// For small corpus, there can be a pruning benefit.
-#[expect(clippy::use_debug)]
 fn bench_small_input(c: &mut Criterion) {
     let mut buf = vec![b'a'; 500];
     for b in 200u8..210 {
-        buf.extend(std::iter::repeat(b).take(5));
+        buf.extend(std::iter::repeat_n(b, 5));
     }
 
     run_bench("small-input", &buf, c);

--- a/benches/compress.rs
+++ b/benches/compress.rs
@@ -56,52 +56,54 @@ fn download_dataset(url: &str, path: impl AsRef<Path>) -> Result<(), Box<dyn Err
     Ok(())
 }
 
+fn run_bench(name: &str, buf: &[u8], c: &mut Criterion) {
+    let mut group = c.benchmark_group(name);
+
+    group.bench_function("train-and-compress", |b| {
+        b.iter_with_large_drop(|| {
+            let compressor = Compressor::train(&vec![&buf]);
+            compressor.compress_bulk(std::hint::black_box(&vec![&buf]))
+        });
+    });
+
+    let compressor = Compressor::train(&vec![&buf]);
+    let mut buffer = Vec::with_capacity(buf.len() * 2);
+    group.throughput(Throughput::Bytes(buf.len() as u64));
+    group.bench_function("compress-only", |b| {
+        b.iter(|| unsafe { compressor.compress_into(&buf, &mut buffer) });
+    });
+
+    unsafe {
+        compressor.compress_into(&buf, &mut buffer);
+    };
+    let decompressor = compressor.decompressor();
+    group.bench_function("decompress", |b| {
+        b.iter_with_large_drop(|| decompressor.decompress(&buffer));
+    });
+
+    group.finish();
+
+    // Report the compression factor for this dataset.
+    let uncompressed_size = buf.len();
+    let compressor = Compressor::train(&vec![&buf]);
+
+    let compressed = compressor.compress_bulk(&vec![&buf]);
+    let compressed_size = compressed.iter().map(|l| l.len()).sum::<usize>();
+    let cf = (uncompressed_size as f64) / (compressed_size as f64);
+    println!(
+        "compressed {name} {uncompressed_size} => {compressed_size}B (compression factor {cf:.2}:1)"
+    )
+}
+
 #[allow(clippy::use_debug)]
 fn bench_dbtext(c: &mut Criterion) {
     fn run_dataset_bench(name: &str, url: &str, path: &str, c: &mut Criterion) {
-        let mut group = c.benchmark_group(name);
         download_dataset(url, path).unwrap();
 
         let mut buf = Vec::new();
-        {
-            let mut file = File::open(path).unwrap();
-            file.read_to_end(&mut buf).unwrap();
-        }
+        File::open(path).unwrap().read_to_end(&mut buf).unwrap();
 
-        group.bench_function("train-and-compress", |b| {
-            b.iter_with_large_drop(|| {
-                let compressor = Compressor::train(&vec![&buf]);
-                compressor.compress_bulk(std::hint::black_box(&vec![&buf]))
-            });
-        });
-
-        let compressor = Compressor::train(&vec![&buf]);
-        let mut buffer = Vec::with_capacity(200 * 1024 * 1024);
-        group.throughput(Throughput::Bytes(buf.len() as u64));
-        group.bench_function("compress-only", |b| {
-            b.iter(|| unsafe { compressor.compress_into(&buf, &mut buffer) });
-        });
-
-        unsafe {
-            compressor.compress_into(&buf, &mut buffer);
-        };
-        let decompressor = compressor.decompressor();
-        group.bench_function("decompress", |b| {
-            b.iter_with_large_drop(|| decompressor.decompress(&buffer));
-        });
-
-        group.finish();
-
-        // Report the compression factor for this dataset.
-        let uncompressed_size = buf.len();
-        let compressor = Compressor::train(&vec![&buf]);
-
-        let compressed = compressor.compress_bulk(&vec![&buf]);
-        let compressed_size = compressed.iter().map(|l| l.len()).sum::<usize>();
-        let cf = (uncompressed_size as f64) / (compressed_size as f64);
-        println!(
-            "compressed {name} {uncompressed_size} => {compressed_size}B (compression factor {cf:.2}:1)"
-        )
+        run_bench(name, &buf, c);
     }
 
     run_dataset_bench(
@@ -126,5 +128,16 @@ fn bench_dbtext(c: &mut Criterion) {
     );
 }
 
-criterion_group!(compress_bench, bench_dbtext);
+/// For small corpus, there can be a pruning benefit.
+#[expect(clippy::use_debug)]
+fn bench_small_input(c: &mut Criterion) {
+    let mut buf = vec![b'a'; 500];
+    for b in 200u8..210 {
+        buf.extend(std::iter::repeat(b).take(5));
+    }
+
+    run_bench("small-input", &buf, c);
+}
+
+criterion_group!(compress_bench, bench_dbtext, bench_small_input);
 criterion_main!(compress_bench);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -529,7 +529,11 @@ const FSST_SAMPLELINE: usize = 512;
 ///
 /// SAFETY: sample_buf must be >= FSST_SAMPLEMAX bytes long. Providing something less may cause unexpected failures.
 #[allow(clippy::ptr_arg)]
-fn make_sample<'a, 'b: 'a>(sample_buf: &'a mut Vec<u8>, str_in: &Vec<&'b [u8]>) -> Vec<&'a [u8]> {
+fn make_sample<'a, 'b: 'a>(
+    sample_buf: &'a mut Vec<u8>,
+    str_in: &Vec<&'b [u8]>,
+    tot_size: usize,
+) -> Vec<&'a [u8]> {
     assert!(
         sample_buf.capacity() >= FSST_SAMPLEMAX,
         "sample_buf.len() < FSST_SAMPLEMAX"
@@ -537,7 +541,6 @@ fn make_sample<'a, 'b: 'a>(sample_buf: &'a mut Vec<u8>, str_in: &Vec<&'b [u8]>) 
 
     let mut sample: Vec<&[u8]> = Vec::new();
 
-    let tot_size: usize = str_in.iter().map(|s| s.len()).sum();
     if tot_size < FSST_SAMPLETARGET {
         return str_in.clone();
     }
@@ -609,7 +612,9 @@ impl Compressor {
         let mut sample_memory = Vec::with_capacity(FSST_SAMPLEMAX);
         let mut pqueue = BinaryHeap::with_capacity(65_536);
 
-        let sample = make_sample(&mut sample_memory, values);
+        let tot_size: usize = values.iter().map(|s| s.len()).sum();
+        let sampled = tot_size >= FSST_SAMPLETARGET;
+        let sample = make_sample(&mut sample_memory, values, tot_size);
         for sample_frac in GENERATIONS {
             for (i, line) in sample.iter().enumerate() {
                 if sample_frac < 128 && ((fsst_hash(i as u64) & 127) as usize) > sample_frac {
@@ -621,7 +626,8 @@ impl Compressor {
 
             // Clear the heap before we use it again
             pqueue.clear();
-            builder.optimize(&counters, sample_frac, &mut pqueue);
+            let prune = sample_frac >= 128 && !sampled;
+            builder.optimize(&counters, sample_frac, &mut pqueue, prune);
             counters.clear();
         }
 
@@ -757,6 +763,7 @@ impl CompressorBuilder {
         counters: &Counter,
         sample_frac: usize,
         pqueue: &mut BinaryHeap<Candidate>,
+        prune: bool,
     ) {
         // Use a HashMap to deduplicate candidates by symbol content, combining gains
         // when the same symbol is encountered via different codes.
@@ -771,7 +778,10 @@ impl CompressorBuilder {
 
             // From the c++ impl:
             // "improves both compression speed (less candidates), but also quality!!"
-            if count < (5 * sample_frac / 128) {
+            // When pruning (final pass, exact counts), lower the threshold to 1
+            // so the pruning check can decide based on cost/benefit.
+            let min_count = if prune { 1 } else { 5 * sample_frac / 128 };
+            if count < min_count {
                 continue;
             }
 
@@ -817,6 +827,17 @@ impl CompressorBuilder {
         let mut n_symbols = 0;
         while !pqueue.is_empty() && n_symbols < 255 {
             let candidate = pqueue.pop().unwrap();
+            if prune {
+                let symbol_len = candidate.symbol.len();
+                let saves = if symbol_len == 1 {
+                    candidate.gain / 8 // undo the 8x single-byte boost
+                } else {
+                    candidate.gain
+                };
+                if saves <= symbol_len + 1 {
+                    continue;
+                }
+            }
             if self.insert(candidate.symbol, candidate.symbol.len()) {
                 n_symbols += 1;
             }

--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -117,3 +117,36 @@ fn test_large_with_rebuild() {
         DECLARATION,
     );
 }
+
+#[test]
+fn test_pruning_small_input() {
+    // 'a' × 100 plus bytes 200..210 appearing once each.
+    // Without pruning, the count >= 5 filter drops the rare bytes.
+    // With pruning, the count threshold is lowered to 1, but
+    // saves (1) <= cost (1+1=2) still filters them out.
+    // Bytes 0xFF appears 3 times: passes the lowered threshold,
+    // AND saves (3) > cost (2), so pruning keeps it.
+    // This proves the pruning path is active: 0xFF would be dropped
+    // by the normal count >= 5 filter but survives via pruning.
+    let mut corpus = vec![b'a'; 100];
+    corpus.extend(200u8..210);
+    corpus.extend([0xFF, 0xFF, 0xFF]);
+
+    // Use multiple sample lines so earlier training generations see data.
+    let compressor = Compressor::train(&vec![&corpus[..30], &corpus[30..60], &corpus[60..]]);
+
+    // 0xFF (count=3) survives: pruning lowers the count threshold to 1,
+    // and saves (3) > cost (2). Bytes 200..210 (count=1) are pruned.
+    assert_eq!(
+        compressor.symbol_table(),
+        &[
+            Symbol::from_slice(b"aa\0\0\0\0\0\0"),
+            Symbol::from_slice(b"aaaaaaaa"),
+            Symbol::from_u8(b'a'),
+            Symbol::from_u8(0xFF),
+        ],
+    );
+
+    let compressed = compressor.compress(&corpus);
+    assert_eq!(compressor.decompressor().decompress(&compressed), corpus);
+}

--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -137,11 +137,25 @@ fn test_pruning_small_input() {
 
     // 0xFF (count=3) survives: pruning lowers the count threshold to 1,
     // and saves (3) > cost (2). Bytes 200..210 (count=1) are pruned.
+    //
+    // Under miri, only 3 generations run (vs 5 normally), so the longest
+    // merged symbol reaches 4 bytes instead of 8.
+    #[cfg(not(miri))]
     assert_eq!(
         compressor.symbol_table(),
         &[
             Symbol::from_slice(b"aa\0\0\0\0\0\0"),
             Symbol::from_slice(b"aaaaaaaa"),
+            Symbol::from_u8(b'a'),
+            Symbol::from_u8(0xFF),
+        ],
+    );
+    #[cfg(miri)]
+    assert_eq!(
+        compressor.symbol_table(),
+        &[
+            Symbol::from_slice(b"aa\0\0\0\0\0\0"),
+            Symbol::from_slice(b"aaaa\0\0\0\0"),
             Symbol::from_u8(b'a'),
             Symbol::from_u8(0xFF),
         ],


### PR DESCRIPTION
When the training corpus is small enough that counts are exact (not sampled), tail-end symbols can cost more table overhead than they save in compression. This adds a pruning step on the final training pass that drops symbols whose savings don't exceed their storage cost (symbol_len + 1 bytes).  

Only activates when the input is below the sampling threshold (16 KiB), so there is no behavior change for large inputs.                                                                                                   But maybe this still helps spiraldb for "weird" users, and generally this pruning is super cheap.

[A Java FSST implementation doing the same ting](https://github.com/maplibre/maplibre-tile-spec/blob/ea02689f8165ee812b43342af4f79cd372654508/java/mlt-core/src/main/java/org/maplibre/mlt/converter/encodings/fsst/SymbolTableBuilder.java#L291).