### PR TITLE
feat: add FSST12 (12-bit-code) variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,11 @@ name = "round_trip"
 bench = false
 test = false
 
+[[example]]
+name = "fsst12_round_trip"
+bench = false
+test = false
+
 [[bench]]
 name = "compress"
 harness = false

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ but it is mostly written from a careful reading of the paper.
 
 ## FSST12 variant
 
-The [`fsst::fsst12`][fsst12-mod] module implements the 12-bit-code FSST variant from the
+The `fsst::fsst12` module implements the 12-bit-code FSST variant from the
 [cwida/fsst][MIT-licensed implementation] reference (also mentioned in the
 [FastLanes File Format paper][fastlanes]). Codes are 12 bits wide (4096 entries), the first 256
 codes are reserved as single-byte identity codes, and there is no escape mechanism. Single-byte
@@ -44,4 +44,3 @@ assert_eq!(decompressed, b"the quick brown fox");
 [whitepaper]: https://www.vldb.org/pvldb/vol13/p2649-boncz.pdf
 [MIT-licensed implementation]: https://github.com/cwida/fsst
 [fastlanes]: https://www.vldb.org/pvldb/vol18/p4629-afroozeh.pdf
-[fsst12-mod]: https://docs.rs/fsst-rs/latest/fsst/fsst12/index.html

--- a/README.md
+++ b/README.md
@@ -23,5 +23,24 @@ but it is mostly written from a careful reading of the paper.
 
 **NOTE: This crate only works on little-endian architectures currently. There are no current plans to support big-endian targets.**
 
+## FSST12 variant
+
+The [`fsst::fsst12`][fsst12-mod] module implements the 12-bit-code FSST variant described in the
+[FastLanes File Format paper][fastlanes]. Codes are 12 bits wide (4096 entries), the first 256
+codes are reserved as single-byte identity codes, and there is no escape mechanism. Single-byte
+fallbacks still cost 1.5× their plaintext bytes, but the penalty is lighter than classic FSST's
+2× escape cost.
+
+```rust
+use fsst::fsst12::Compressor12;
+
+let compressor = Compressor12::train(&[b"the quick brown fox".as_slice()]);
+let compressed = compressor.compress(b"the quick brown fox");
+let decompressed = compressor.decompressor().decompress(&compressed);
+assert_eq!(decompressed, b"the quick brown fox");
+```
+
 [whitepaper]: https://www.vldb.org/pvldb/vol13/p2649-boncz.pdf
 [MIT-licensed implementation]: https://github.com/cwida/fsst
+[fastlanes]: https://www.vldb.org/pvldb/vol18/p4629-afroozeh.pdf
+[fsst12-mod]: https://docs.rs/fsst-rs/latest/fsst/fsst12/index.html

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ but it is mostly written from a careful reading of the paper.
 
 ## FSST12 variant
 
-The [`fsst::fsst12`][fsst12-mod] module implements the 12-bit-code FSST variant described in the
-[FastLanes File Format paper][fastlanes]. Codes are 12 bits wide (4096 entries), the first 256
+The [`fsst::fsst12`][fsst12-mod] module implements the 12-bit-code FSST variant from the
+[cwida/fsst][MIT-licensed implementation] reference (also mentioned in the
+[FastLanes File Format paper][fastlanes]). Codes are 12 bits wide (4096 entries), the first 256
 codes are reserved as single-byte identity codes, and there is no escape mechanism. Single-byte
 fallbacks still cost 1.5× their plaintext bytes, but the penalty is lighter than classic FSST's
 2× escape cost.

--- a/benches/compress.rs
+++ b/benches/compress.rs
@@ -14,6 +14,7 @@ use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 
 use curl::easy::Easy;
 use fsst::Compressor;
+use fsst::fsst12::Compressor12;
 
 fn download_dataset(url: &str, path: impl AsRef<Path>) -> Result<(), Box<dyn Error>> {
     let target = path.as_ref();
@@ -95,6 +96,42 @@ fn run_bench(name: &str, buf: &[u8], c: &mut Criterion) {
     )
 }
 
+fn run_bench_fsst12(name: &str, buf: &[u8], c: &mut Criterion) {
+    let mut group = c.benchmark_group(format!("fsst12/{name}"));
+
+    group.bench_function("train-and-compress", |b| {
+        b.iter_with_large_drop(|| {
+            let compressor = Compressor12::train(&[buf]);
+            compressor.compress(std::hint::black_box(buf))
+        });
+    });
+
+    let compressor = Compressor12::train(&[buf]);
+    let mut buffer = Vec::with_capacity(buf.len() * 3 / 2 + 2);
+    group.throughput(Throughput::Bytes(buf.len() as u64));
+    group.bench_function("compress-only", |b| {
+        // SAFETY: `buffer` capacity holds the worst-case FSST12 output.
+        b.iter(|| unsafe { compressor.compress_into(buf, &mut buffer) });
+    });
+
+    // SAFETY: same as above.
+    unsafe { compressor.compress_into(buf, &mut buffer) };
+    let decompressor = compressor.decompressor();
+    group.bench_function("decompress", |b| {
+        b.iter_with_large_drop(|| decompressor.decompress(&buffer));
+    });
+
+    group.finish();
+
+    let uncompressed_size = buf.len();
+    let compressed = Compressor12::train(&[buf]).compress(buf);
+    let cf = (uncompressed_size as f64) / (compressed.len() as f64);
+    println!(
+        "fsst12 compressed {name} {uncompressed_size} => {}B (compression factor {cf:.2}:1)",
+        compressed.len()
+    );
+}
+
 #[allow(clippy::use_debug)]
 fn bench_dbtext(c: &mut Criterion) {
     fn run_dataset_bench(name: &str, url: &str, path: &str, c: &mut Criterion) {
@@ -104,6 +141,7 @@ fn bench_dbtext(c: &mut Criterion) {
         File::open(path).unwrap().read_to_end(&mut buf).unwrap();
 
         run_bench(name, &buf, c);
+        run_bench_fsst12(name, &buf, c);
     }
 
     run_dataset_bench(
@@ -136,6 +174,7 @@ fn bench_small_input(c: &mut Criterion) {
     }
 
     run_bench("small-input", &buf, c);
+    run_bench_fsst12("small-input", &buf, c);
 }
 
 criterion_group!(compress_bench, bench_dbtext, bench_small_input);

--- a/benches/micro.rs
+++ b/benches/micro.rs
@@ -261,9 +261,7 @@ fn bench_fsst12_micro(c: &mut Criterion) {
     let identity_compressor = CompressorBuilder12::new().build();
     group.bench_function("compress", |b| {
         // SAFETY: output_buf capacity holds the worst-case FSST12 output.
-        b.iter(|| unsafe {
-            identity_compressor.compress_into(&test_string, &mut output_buf)
-        });
+        b.iter(|| unsafe { identity_compressor.compress_into(&test_string, &mut output_buf) });
     });
     // SAFETY: same.
     unsafe { identity_compressor.compress_into(&test_string, &mut output_buf) };

--- a/benches/micro.rs
+++ b/benches/micro.rs
@@ -2,6 +2,7 @@
 
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 
+use fsst::fsst12::{Compressor12, CompressorBuilder12};
 use fsst::{CompressorBuilder, Symbol};
 
 fn one_megabyte(seed: &[u8]) -> Vec<u8> {
@@ -225,10 +226,78 @@ fn bench_compress(c: &mut Criterion) {
     let _ = std::hint::black_box(output_buf);
 }
 
+fn bench_fsst12_micro(c: &mut Criterion) {
+    let test_string = one_megabyte(b"abcdefgh");
+    let mut output_buf: Vec<u8> = Vec::with_capacity(test_string.len() * 3 / 2 + 2);
+    let mut decoded_buf: Vec<u8> = Vec::with_capacity(test_string.len() + 8);
+
+    // Best case: one learned 8-byte symbol covers every input position.
+    let mut group = c.benchmark_group("fsst12/cf=8");
+    group.throughput(Throughput::Bytes(test_string.len() as u64));
+    let mut builder = CompressorBuilder12::new();
+    assert!(builder.insert(Symbol::from_slice(b"abcdefgh"), 8));
+    let compressor = builder.build();
+    group.bench_function("compress", |b| {
+        // SAFETY: output_buf capacity holds the worst-case FSST12 output.
+        b.iter(|| unsafe { compressor.compress_into(&test_string, &mut output_buf) });
+    });
+    // SAFETY: same capacity invariant as above.
+    unsafe { compressor.compress_into(&test_string, &mut output_buf) };
+    let decompressor = compressor.decompressor();
+    group.bench_function("decompress", |b| {
+        b.iter(|| {
+            let len = decompressor.decompress_into(&output_buf, decoded_buf.spare_capacity_mut());
+            // SAFETY: decompress_into initialized exactly `len` bytes.
+            unsafe { decoded_buf.set_len(len) };
+            let _ = std::hint::black_box(&decoded_buf);
+            decoded_buf.clear();
+        });
+    });
+    group.finish();
+
+    // Worst case: no learned symbols, every byte through an identity code.
+    let mut group = c.benchmark_group("fsst12/identity");
+    group.throughput(Throughput::Bytes(test_string.len() as u64));
+    let identity_compressor = CompressorBuilder12::new().build();
+    group.bench_function("compress", |b| {
+        // SAFETY: output_buf capacity holds the worst-case FSST12 output.
+        b.iter(|| unsafe {
+            identity_compressor.compress_into(&test_string, &mut output_buf)
+        });
+    });
+    // SAFETY: same.
+    unsafe { identity_compressor.compress_into(&test_string, &mut output_buf) };
+    let identity_decompressor = identity_compressor.decompressor();
+    group.bench_function("decompress", |b| {
+        b.iter(|| {
+            let len = identity_decompressor
+                .decompress_into(&output_buf, decoded_buf.spare_capacity_mut());
+            unsafe { decoded_buf.set_len(len) };
+            let _ = std::hint::black_box(&decoded_buf);
+            decoded_buf.clear();
+        });
+    });
+    group.finish();
+
+    let mut group = c.benchmark_group("fsst12/train-and-compress");
+    group.throughput(Throughput::Bytes(test_string.len() as u64));
+    group.bench_function("1mb-abcdefgh", |b| {
+        b.iter_with_large_drop(|| {
+            let compressor = Compressor12::train(&[test_string.as_slice()]);
+            compressor.compress(std::hint::black_box(&test_string))
+        });
+    });
+    group.finish();
+
+    let _ = std::hint::black_box(&output_buf);
+    let _ = std::hint::black_box(&decoded_buf);
+}
+
 criterion_group!(
     bench_micro,
     bench_compress,
     bench_decompress_short,
-    bench_decompress_escape_heavy
+    bench_decompress_escape_heavy,
+    bench_fsst12_micro
 );
 criterion_main!(bench_micro);

--- a/examples/fsst12_round_trip.rs
+++ b/examples/fsst12_round_trip.rs
@@ -1,0 +1,25 @@
+//! End-to-end example using the FSST12 (12-bit code) variant.
+
+use core::str;
+
+use fsst::fsst12::Compressor12;
+
+fn main() {
+    let phrase = "the quick brown fox jumped over the lazy dog. ";
+    let sample: String = phrase.repeat(32);
+
+    let trained = Compressor12::train(&[sample.as_bytes()]);
+    let compressed = trained.compress(sample.as_bytes());
+    println!(
+        "compressed: {} => {} bytes ({} learned symbols, {:.2}:1 ratio)",
+        sample.len(),
+        compressed.len(),
+        trained.symbol_table().len() - 256,
+        sample.len() as f64 / compressed.len() as f64,
+    );
+
+    let decoded = trained.decompressor().decompress(&compressed);
+    let output = str::from_utf8(&decoded).unwrap();
+    assert_eq!(output, sample);
+    println!("decoded: len={} bytes round-tripped", decoded.len());
+}

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -26,3 +26,31 @@ path = "fuzz_targets/fuzz_compress.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_fsst12_train"
+path = "fuzz_targets/fuzz_fsst12_train.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_fsst12_compress"
+path = "fuzz_targets/fuzz_fsst12_compress.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_train_then_compress"
+path = "fuzz_targets/fuzz_train_then_compress.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_fsst12_train_then_compress"
+path = "fuzz_targets/fuzz_fsst12_train_then_compress.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_compress.rs
+++ b/fuzz/fuzz_targets/fuzz_compress.rs
@@ -1,5 +1,8 @@
 #![no_main]
 
+// Trains and compresses on the same buffer, so every byte of the input is in the training
+// corpus. PHT-miss and unseen-byte paths are exercised by `fuzz_train_then_compress`.
+
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/fuzz_fsst12_compress.rs
+++ b/fuzz/fuzz_targets/fuzz_fsst12_compress.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+// Trains and compresses on the same buffer, so every byte of the input is in the training
+// corpus. PHT-miss and unseen-byte paths are exercised by
+// `fuzz_fsst12_train_then_compress`.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let compressor = fsst::fsst12::Compressor12::train(&[data]);
+    let compressed = compressor.compress(data);
+    let decompressed = compressor.decompressor().decompress(&compressed);
+    assert_eq!(&decompressed, data);
+});

--- a/fuzz/fuzz_targets/fuzz_fsst12_train.rs
+++ b/fuzz/fuzz_targets/fuzz_fsst12_train.rs
@@ -1,0 +1,7 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = fsst::fsst12::Compressor12::train(&[data]);
+});

--- a/fuzz/fuzz_targets/fuzz_fsst12_train_then_compress.rs
+++ b/fuzz/fuzz_targets/fuzz_fsst12_train_then_compress.rs
@@ -1,0 +1,16 @@
+#![no_main]
+
+// Trains on one byte sequence and compresses a separate `payload`. Unlike
+// `fuzz_fsst12_compress`, the compress input may contain bytes or sequences the trainer
+// never saw, exercising the identity-fallback and PHT-miss code paths.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|input: (Vec<Vec<u8>>, Vec<u8>)| {
+    let (train_corpus, payload) = input;
+    let lines: Vec<&[u8]> = train_corpus.iter().map(|v| v.as_slice()).collect();
+    let compressor = fsst::fsst12::Compressor12::train(&lines);
+    let compressed = compressor.compress(&payload);
+    let decompressed = compressor.decompressor().decompress(&compressed);
+    assert_eq!(decompressed, payload);
+});

--- a/fuzz/fuzz_targets/fuzz_train_then_compress.rs
+++ b/fuzz/fuzz_targets/fuzz_train_then_compress.rs
@@ -1,0 +1,16 @@
+#![no_main]
+
+// Trains on one byte sequence and compresses a separate `payload`. Unlike `fuzz_compress`,
+// the compress input may contain bytes or sequences the trainer never saw, exercising the
+// escape path and PHT-miss code paths.
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|input: (Vec<Vec<u8>>, Vec<u8>)| {
+    let (train_corpus, payload) = input;
+    let lines: Vec<&[u8]> = train_corpus.iter().map(|v| v.as_slice()).collect();
+    let compressor = fsst::Compressor::train(&lines);
+    let compressed = compressor.compress(&payload);
+    let decompressed = compressor.decompressor().decompress(&compressed);
+    assert_eq!(decompressed, payload);
+});

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -511,9 +511,9 @@ impl CompressorBuilder {
 ///
 /// [FSST paper]: https://www.vldb.org/pvldb/vol13/p2649-boncz.pdf
 #[cfg(not(miri))]
-pub(crate) const GENERATIONS: [usize; 5] = [8usize, 38, 68, 98, 128];
+const GENERATIONS: [usize; 5] = [8usize, 38, 68, 98, 128];
 #[cfg(miri)]
-pub(crate) const GENERATIONS: [usize; 3] = [8usize, 38, 128];
+const GENERATIONS: [usize; 3] = [8usize, 38, 128];
 
 pub(crate) const FSST_SAMPLETARGET: usize = 1 << 14;
 const FSST_SAMPLELINE: usize = 512;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -511,18 +511,18 @@ impl CompressorBuilder {
 ///
 /// [FSST paper]: https://www.vldb.org/pvldb/vol13/p2649-boncz.pdf
 #[cfg(not(miri))]
-const GENERATIONS: [usize; 5] = [8usize, 38, 68, 98, 128];
+pub(crate) const GENERATIONS: [usize; 5] = [8usize, 38, 68, 98, 128];
 #[cfg(miri)]
-const GENERATIONS: [usize; 3] = [8usize, 38, 128];
+pub(crate) const GENERATIONS: [usize; 3] = [8usize, 38, 128];
 
-const FSST_SAMPLETARGET: usize = 1 << 14;
+pub(crate) const FSST_SAMPLETARGET: usize = 1 << 14;
 const FSST_SAMPLELINE: usize = 512;
 
 /// Create a sample from a set of strings in the input.
 ///
 /// The sample is picked based on criteria from the C++ implementation, and it
 /// is a vector of subranges of the input strings `str_in`.
-fn make_sample<'a>(str_in: &[&'a [u8]], tot_size: usize) -> Vec<&'a [u8]> {
+pub(crate) fn make_sample<'a>(str_in: &[&'a [u8]], tot_size: usize) -> Vec<&'a [u8]> {
     let mut sample: Vec<&[u8]> = Vec::new();
 
     if tot_size < FSST_SAMPLETARGET {

--- a/src/fsst12/builder.rs
+++ b/src/fsst12/builder.rs
@@ -1,0 +1,699 @@
+//! Builds a [`Compressor12`] from a corpus of text.
+//!
+//! Same generational loop as [`crate::builder`], with two adjustments for FSST12:
+//! length-1 candidates are skipped (they are pre-reserved as identity codes), and no
+//! escape penalty is charged.
+
+use crate::{
+    Symbol,
+    builder::{FSST_SAMPLETARGET, GENERATIONS, fsst_hash, make_sample},
+    compare_masked,
+};
+use rustc_hash::{FxBuildHasher, FxHashMap};
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
+use super::{
+    CODE12_LEN_SHIFT, CODE12_MASK, Compressor12, FSST12_MAX_LEARNED, FSST12_MAX_SYMBOLS,
+    FSST12_RESERVED_CODES, FSST12_TWO_BYTE_TABLE_SIZE, lossy_pht::LossyPht12, pack_code12,
+};
+
+/// Sentinel for `prev_code` before the first emission. Stored as the highest row of
+/// [`Counter12::pair_index`]; never appears in `code1_index`.
+const FSST12_NO_PREV: u16 = FSST12_MAX_SYMBOLS as u16;
+
+const COUNTS1_SIZE: usize = FSST12_MAX_SYMBOLS + 1;
+const COUNTS2_SIZE: usize = COUNTS1_SIZE * COUNTS1_SIZE;
+
+#[derive(Clone, Copy, Debug)]
+struct CodesBitmap12 {
+    words: [u64; 65],
+}
+
+assert_sizeof!(CodesBitmap12 => 520);
+
+impl Default for CodesBitmap12 {
+    fn default() -> Self {
+        Self { words: [0; 65] }
+    }
+}
+
+impl CodesBitmap12 {
+    fn set(&mut self, index: usize) {
+        debug_assert!(index <= FSST12_NO_PREV as usize);
+        self.words[index >> 6] |= 1u64 << (index & 63);
+    }
+
+    fn is_set(&self, index: usize) -> bool {
+        debug_assert!(index <= FSST12_NO_PREV as usize);
+        self.words[index >> 6] & (1u64 << (index & 63)) != 0
+    }
+
+    fn codes(&self) -> CodesIter12<'_> {
+        CodesIter12 {
+            inner: self,
+            index: 0,
+            block: self.words[0],
+            reference: 0,
+        }
+    }
+
+    fn clear(&mut self) {
+        for w in &mut self.words {
+            *w = 0;
+        }
+    }
+}
+
+struct CodesIter12<'a> {
+    inner: &'a CodesBitmap12,
+    index: usize,
+    block: u64,
+    reference: usize,
+}
+
+impl Iterator for CodesIter12<'_> {
+    type Item = u16;
+
+    fn next(&mut self) -> Option<u16> {
+        while self.block == 0 {
+            self.index += 1;
+            if self.index >= self.inner.words.len() {
+                return None;
+            }
+            self.block = self.inner.words[self.index];
+            self.reference = self.index * 64;
+        }
+        let position = self.block.trailing_zeros() as usize;
+        let code = self.reference + position;
+        self.reference = code + 1;
+        self.block = if position == 63 {
+            0
+        } else {
+            self.block >> (1 + position)
+        };
+        Some(code as u16)
+    }
+}
+
+/// Single-code and code-pair counts for one training generation.
+///
+/// `counts2` is left uninitialized; reads only happen for slots flagged in `pair_index`,
+/// which is set on each write.
+///
+/// `counts2` is a dense `4097 × 4097 × usize` table, ~128 MB. This is a virtual
+/// reservation: on Linux/macOS the allocation is large enough to land on `mmap` zero-fill,
+/// so physical pages are only committed when written. The bitmap-guarded access pattern
+/// means the touched footprint tracks the number of distinct code pairs seen in a
+/// generation — typically a few MB even for large corpora. A sparse `FxHashMap` would
+/// shrink the virtual reservation but slow down `record_count2` (the training hot path)
+/// by an order of magnitude, so the dense layout wins on every target with adequate
+/// address space. Note: this is unsuitable for 32-bit targets.
+#[derive(Debug, Clone)]
+struct Counter12 {
+    counts1: Vec<usize>,
+    /// Row-major over (prev_code, code).
+    counts2: Vec<usize>,
+    code1_index: CodesBitmap12,
+    /// Per-row bitmap into `counts2`. The extra row at [`FSST12_NO_PREV`] records
+    /// first-emission codes.
+    pair_index: Vec<CodesBitmap12>,
+}
+
+impl Counter12 {
+    fn new() -> Self {
+        let mut counts1 = Vec::with_capacity(COUNTS1_SIZE);
+        let mut counts2 = Vec::with_capacity(COUNTS2_SIZE);
+        // SAFETY: reads of these vectors are gated on the bitmap indexes; an unset slot
+        // is never read.
+        unsafe {
+            counts1.set_len(COUNTS1_SIZE);
+            counts2.set_len(COUNTS2_SIZE);
+        }
+        Self {
+            counts1,
+            counts2,
+            code1_index: CodesBitmap12::default(),
+            pair_index: vec![CodesBitmap12::default(); COUNTS1_SIZE],
+        }
+    }
+
+    #[inline]
+    fn record_count1(&mut self, code: u16) {
+        let idx = code as usize;
+        let base = if self.code1_index.is_set(idx) {
+            self.counts1[idx]
+        } else {
+            0
+        };
+        self.counts1[idx] = base + 1;
+        self.code1_index.set(idx);
+    }
+
+    #[inline]
+    fn record_count2(&mut self, code1: u16, code2: u16) {
+        let i1 = code1 as usize;
+        let i2 = code2 as usize;
+        let pair_idx = i1 * COUNTS1_SIZE + i2;
+        if self.pair_index[i1].is_set(i2) {
+            self.counts2[pair_idx] += 1;
+        } else {
+            self.counts2[pair_idx] = 1;
+        }
+        self.pair_index[i1].set(i2);
+    }
+
+    #[inline]
+    fn count1(&self, code: u16) -> usize {
+        debug_assert!(self.code1_index.is_set(code as usize));
+        self.counts1[code as usize]
+    }
+
+    #[inline]
+    fn count2(&self, code1: u16, code2: u16) -> usize {
+        debug_assert!(self.pair_index[code1 as usize].is_set(code2 as usize));
+        self.counts2[(code1 as usize) * COUNTS1_SIZE + (code2 as usize)]
+    }
+
+    fn first_codes(&self) -> CodesIter12<'_> {
+        self.code1_index.codes()
+    }
+
+    fn second_codes(&self, code1: u16) -> CodesIter12<'_> {
+        self.pair_index[code1 as usize].codes()
+    }
+
+    fn clear(&mut self) {
+        self.code1_index.clear();
+        for row in &mut self.pair_index {
+            row.clear();
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+struct Candidate12 {
+    gain: usize,
+    symbol: Symbol,
+}
+
+impl Eq for Candidate12 {}
+
+impl PartialEq<Self> for Candidate12 {
+    fn eq(&self, other: &Self) -> bool {
+        (self.gain, self.symbol.len()) == (other.gain, other.symbol.len())
+    }
+}
+
+impl PartialOrd<Self> for Candidate12 {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Candidate12 {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (self.gain, self.symbol.len()).cmp(&(other.gain, other.symbol.len()))
+    }
+}
+
+/// Builder for a [`Compressor12`].
+///
+/// A fresh builder starts with the 256 reserved single-byte literal codes populated.
+/// Callers add learned symbols of length 2-8 via [`insert`][Self::insert], up to
+/// [`FSST12_MAX_SYMBOLS`].
+pub struct CompressorBuilder12 {
+    symbols: Vec<Symbol>,
+    lengths: Vec<u8>,
+    /// Indexed by the `u16` of the next two input bytes; each slot is `pack_code12(code,
+    /// len)`.
+    codes_two_byte: Vec<u16>,
+    lossy_pht: LossyPht12,
+}
+
+impl CompressorBuilder12 {
+    /// Create a new builder with the 256 reserved single-byte literal codes pre-populated.
+    pub fn new() -> Self {
+        let mut symbols = Vec::with_capacity(FSST12_MAX_SYMBOLS);
+        let mut lengths = Vec::with_capacity(FSST12_MAX_SYMBOLS);
+        for byte in 0u16..256 {
+            symbols.push(Symbol::from_u8(byte as u8));
+            lengths.push(1);
+        }
+        let mut codes_two_byte = Vec::with_capacity(FSST12_TWO_BYTE_TABLE_SIZE);
+        for i in 0..FSST12_TWO_BYTE_TABLE_SIZE {
+            let low_byte = (i & 0xFF) as u16;
+            codes_two_byte.push(pack_code12(low_byte, 1));
+        }
+        Self {
+            symbols,
+            lengths,
+            codes_two_byte,
+            lossy_pht: LossyPht12::new(),
+        }
+    }
+
+    /// Returns `false` if the table is full or a 3+ byte symbol collides in the PHT.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `len` is not in `2..=8`.
+    pub fn insert(&mut self, symbol: Symbol, len: usize) -> bool {
+        assert!(
+            (2..=8).contains(&len),
+            "FSST12 learned symbols must be 2-8 bytes; single-byte symbols are reserved"
+        );
+        if self.symbols.len() >= FSST12_MAX_SYMBOLS {
+            return false;
+        }
+        let code = self.symbols.len() as u16;
+        if len == 2 {
+            let key = (symbol.to_u64() & 0xFFFF) as usize;
+            self.codes_two_byte[key] = pack_code12(code, 2);
+        } else if !self.lossy_pht.insert(symbol, len as u8, code) {
+            return false;
+        }
+        self.symbols.push(symbol);
+        self.lengths.push(len as u8);
+        true
+    }
+
+    /// Reset to a fresh builder. Reverts lookup structures slot-by-slot to avoid
+    /// rezeroing the 128 KB two-byte table between training generations.
+    fn clear(&mut self) {
+        for i in FSST12_RESERVED_CODES..self.symbols.len() {
+            let symbol = self.symbols[i];
+            let len = self.lengths[i];
+            if len == 2 {
+                let key = (symbol.to_u64() & 0xFFFF) as usize;
+                let low_byte = (key & 0xFF) as u16;
+                self.codes_two_byte[key] = pack_code12(low_byte, 1);
+            } else {
+                self.lossy_pht.remove(symbol);
+            }
+        }
+        self.symbols.truncate(FSST12_RESERVED_CODES);
+        self.lengths.truncate(FSST12_RESERVED_CODES);
+    }
+
+    /// Finalize the builder into a [`Compressor12`].
+    pub fn build(self) -> Compressor12 {
+        Compressor12 {
+            symbols: self.symbols,
+            lengths: self.lengths,
+            codes_two_byte: self.codes_two_byte,
+            lossy_pht: self.lossy_pht,
+        }
+    }
+
+    /// Builder-side analogue of [`Compressor12::compress_word`], used during training.
+    #[inline]
+    fn find_longest_symbol(&self, word: u64, remaining: usize) -> (u16, u8) {
+        if remaining >= 3 {
+            let entry = self.lossy_pht.lookup(word);
+            if !entry.is_unused() {
+                let len = ((64 - entry.ignored_bits) >> 3) as u8;
+                if (len as usize) <= remaining
+                    && compare_masked(word, entry.symbol.to_u64(), entry.ignored_bits)
+                {
+                    return (entry.code, len);
+                }
+            }
+        }
+        if remaining >= 2 {
+            let packed = self.codes_two_byte[(word as u16) as usize];
+            return (packed & CODE12_MASK, (packed >> CODE12_LEN_SHIFT) as u8);
+        }
+        ((word & 0xFF) as u16, 1)
+    }
+
+    /// Greedy-compress `sample`, recording emitted codes and code-pairs into `counter`.
+    /// Returns a coarse savings tally (sum of `len - 1`) used only as a metric.
+    fn compress_count(&self, sample: &[u8], counter: &mut Counter12) -> usize {
+        if sample.is_empty() {
+            return 0;
+        }
+        let mut pos = 0;
+        let mut prev_code: u16 = FSST12_NO_PREV;
+        let mut gain = 0usize;
+        while pos < sample.len() {
+            let (word, remaining) = read_word_padded(sample, pos);
+            let (code, len) = self.find_longest_symbol(word, remaining);
+            let len_usz = len as usize;
+            gain += len_usz.saturating_sub(1);
+
+            counter.record_count1(code);
+            counter.record_count2(prev_code, code);
+
+            // Also record the first byte alone, so the optimizer can rediscover a
+            // single-byte's pair statistics even when it was absorbed into a longer match.
+            if len_usz > 1 {
+                let first_byte_code = self.symbols[code as usize].first_byte() as u16;
+                counter.record_count1(first_byte_code);
+                counter.record_count2(prev_code, first_byte_code);
+            }
+
+            pos += len_usz;
+            prev_code = code;
+        }
+        gain
+    }
+
+    /// Reset and repopulate with the highest-gain candidates from `counters`.
+    fn optimize(
+        &mut self,
+        counters: &Counter12,
+        sample_frac: usize,
+        pqueue: &mut BinaryHeap<Candidate12>,
+        prune: bool,
+    ) {
+        // Deduplicate candidates by symbol content.
+        let mut candidates: FxHashMap<Symbol, usize> =
+            FxHashMap::with_capacity_and_hasher(4096, FxBuildHasher);
+
+        for code1 in counters.first_codes() {
+            let symbol1 = self.symbols[code1 as usize];
+            let symbol1_len = symbol1.len();
+            let count = counters.count1(code1);
+
+            let min_count = if prune { 1 } else { 5 * sample_frac / 128 };
+            if count < min_count {
+                continue;
+            }
+
+            // Length-1 symbols are pre-reserved as identity codes; they cannot become
+            // learned candidates on their own. They remain valid as the left half of a
+            // merge, which the second loop covers.
+            if symbol1_len >= 2 {
+                let gain = count * symbol1_len;
+                *candidates.entry(symbol1).or_insert(0) += gain;
+            }
+
+            if sample_frac >= 128 || symbol1_len == 8 {
+                continue;
+            }
+
+            for code2 in counters.second_codes(code1) {
+                let symbol2 = self.symbols[code2 as usize];
+                let symbol2_len = symbol2.len();
+                if symbol1_len + symbol2_len > 8 {
+                    continue;
+                }
+                let new_symbol = symbol1.concat(symbol2);
+                let new_len = new_symbol.len();
+                if new_len < 2 {
+                    // Happens when `symbol2 == Symbol::ZERO` is appended; the trailing
+                    // zero is indistinguishable from padding.
+                    continue;
+                }
+                let gain = counters.count2(code1, code2) * new_len;
+                *candidates.entry(new_symbol).or_insert(0) += gain;
+            }
+        }
+
+        for (symbol, gain) in candidates {
+            pqueue.push(Candidate12 { symbol, gain });
+        }
+
+        self.clear();
+
+        let mut n_learned = 0usize;
+        while let Some(candidate) = pqueue.pop() {
+            if n_learned >= FSST12_MAX_LEARNED {
+                break;
+            }
+            let len = candidate.symbol.len();
+            if prune && candidate.gain <= len + 1 {
+                continue;
+            }
+            if self.insert(candidate.symbol, len) {
+                n_learned += 1;
+            }
+        }
+    }
+}
+
+impl Default for CompressorBuilder12 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Compressor12 {
+    /// Train an FSST12 compressor on a corpus of byte slices. The table grows up to
+    /// [`FSST12_MAX_LEARNED`] learned symbols.
+    pub fn train(values: &[&[u8]]) -> Self {
+        let mut builder = CompressorBuilder12::new();
+        if values.is_empty() {
+            return builder.build();
+        }
+
+        let mut counters = Counter12::new();
+        let mut pqueue: BinaryHeap<Candidate12> = BinaryHeap::with_capacity(1 << 16);
+
+        let tot_size: usize = values.iter().map(|s| s.len()).sum();
+        let sampled = tot_size >= FSST_SAMPLETARGET;
+        let sample = make_sample(values, tot_size);
+        for sample_frac in GENERATIONS {
+            for (i, line) in sample.iter().enumerate() {
+                if sample_frac < 128 && ((fsst_hash(i as u64) & 127) as usize) > sample_frac {
+                    continue;
+                }
+                builder.compress_count(line, &mut counters);
+            }
+            pqueue.clear();
+            let prune = sample_frac >= 128 && !sampled;
+            builder.optimize(&counters, sample_frac, &mut pqueue, prune);
+            counters.clear();
+        }
+
+        builder.build()
+    }
+}
+
+/// Reads up to 8 bytes from `pos` into a little-endian `u64`, zero-padding if fewer
+/// remain. Returns `(word, remaining)` with `remaining` capped at 8.
+#[inline]
+fn read_word_padded(input: &[u8], pos: usize) -> (u64, usize) {
+    let remaining = input.len() - pos;
+    if remaining >= 8 {
+        // SAFETY: at least 8 bytes are available starting at `pos`.
+        let word = unsafe { input.as_ptr().add(pos).cast::<u64>().read_unaligned() };
+        (word, 8)
+    } else {
+        let mut bytes = [0u8; 8];
+        bytes[..remaining].copy_from_slice(&input[pos..]);
+        (u64::from_le_bytes(bytes), remaining)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fsst12::FSST12_RESERVED_CODES;
+
+    #[test]
+    fn builder_prepopulates_reserved_codes() {
+        let compressor = CompressorBuilder12::new().build();
+        let table = compressor.symbol_table();
+        let lengths = compressor.symbol_lengths();
+        assert_eq!(table.len(), FSST12_RESERVED_CODES);
+        for (code, sym) in table.iter().enumerate() {
+            assert_eq!(sym.first_byte(), code as u8);
+            assert_eq!(lengths[code], 1);
+        }
+    }
+
+    #[test]
+    fn builder_inserts_learned_symbol() {
+        let mut builder = CompressorBuilder12::new();
+        assert!(builder.insert(Symbol::from_slice(b"abcdefgh"), 8));
+        let compressor = builder.build();
+        assert_eq!(compressor.symbol_table().len(), FSST12_RESERVED_CODES + 1);
+        assert_eq!(compressor.symbol_lengths()[FSST12_RESERVED_CODES], 8);
+    }
+
+    #[test]
+    fn builder_caps_at_max_symbols() {
+        let mut builder = CompressorBuilder12::new();
+        let two_byte = Symbol::from_slice(&[b'a', b'b', 0, 0, 0, 0, 0, 0]);
+        for _ in 0..FSST12_MAX_LEARNED {
+            assert!(builder.insert(two_byte, 2));
+        }
+        assert!(!builder.insert(two_byte, 2));
+    }
+
+    #[test]
+    #[should_panic(expected = "single-byte symbols are reserved")]
+    fn builder_rejects_single_byte_inserts() {
+        let mut builder = CompressorBuilder12::new();
+        builder.insert(Symbol::from_u8(b'a'), 1);
+    }
+
+    #[test]
+    fn builder_clear_resets_to_reserved_codes_only() {
+        let mut builder = CompressorBuilder12::new();
+        assert!(builder.insert(Symbol::from_slice(b"ab\0\0\0\0\0\0"), 2));
+        assert!(builder.insert(Symbol::from_slice(b"abcdefgh"), 8));
+        builder.clear();
+
+        // The codes_two_byte entry for "ab" must be back to the identity for byte 'a'.
+        let compressor = builder.build();
+        assert_eq!(compressor.symbol_table().len(), FSST12_RESERVED_CODES);
+        let compressed = compressor.compress(b"ab");
+        // Two identity codes, packed: 0x61 | (0x62 << 12) = 0x062061.
+        assert_eq!(compressed, vec![0x61, 0x20, 0x06]);
+    }
+
+    #[test]
+    fn train_empty_corpus_yields_identity_only_table() {
+        let compressor = Compressor12::train(&[]);
+        assert_eq!(compressor.symbol_table().len(), FSST12_RESERVED_CODES);
+    }
+
+    #[test]
+    fn train_round_trip_with_unseen_bytes() {
+        let corpus: &[&[u8]] = &[b"hello world".as_slice(), b"hello rust"];
+        let compressor = Compressor12::train(corpus);
+        let plaintext: &[u8] = b"\x00\x01\x02!@# unseen ~~~";
+        let compressed = compressor.compress(plaintext);
+        let decompressed = compressor.decompressor().decompress(&compressed);
+        assert_eq!(decompressed, plaintext);
+    }
+
+    #[test]
+    fn train_compresses_repetitive_corpus_below_raw_size() {
+        let phrase: &[u8] = b"the quick brown fox jumps over the lazy dog. ";
+        let mut text = Vec::with_capacity(phrase.len() * 64);
+        for _ in 0..64 {
+            text.extend_from_slice(phrase);
+        }
+        let corpus: Vec<&[u8]> = vec![text.as_slice()];
+        let compressor = Compressor12::train(&corpus);
+        assert!(
+            compressor.symbol_table().len() > FSST12_RESERVED_CODES,
+            "training should learn at least one symbol; got {} entries",
+            compressor.symbol_table().len()
+        );
+
+        let compressed = compressor.compress(&text);
+        let decompressed = compressor.decompressor().decompress(&compressed);
+        assert_eq!(decompressed, text);
+        assert!(
+            compressed.len() < text.len(),
+            "compressed {} should be smaller than raw {}",
+            compressed.len(),
+            text.len(),
+        );
+    }
+
+    #[test]
+    fn bitmap_round_trips_set_codes() {
+        let mut map = CodesBitmap12::default();
+        map.set(10);
+        map.set(100);
+        map.set(500);
+        map.set(4000);
+        let codes: Vec<u16> = map.codes().collect();
+        assert_eq!(codes, vec![10u16, 100, 500, 4000]);
+
+        let map = CodesBitmap12::default();
+        assert!(map.codes().collect::<Vec<_>>().is_empty());
+
+        // First bit in each 64-bit word.
+        let mut map = CodesBitmap12::default();
+        for w in 0..64 {
+            map.set(64 * w);
+        }
+        assert_eq!(
+            map.codes().collect::<Vec<_>>(),
+            (0u16..64).map(|w| 64 * w).collect::<Vec<_>>(),
+        );
+
+        // Fully saturated: 0..=FSST12_NO_PREV.
+        let mut map = CodesBitmap12::default();
+        for i in 0..=(FSST12_NO_PREV as usize) {
+            map.set(i);
+        }
+        let collected: Vec<u16> = map.codes().collect();
+        assert_eq!(collected.len(), FSST12_NO_PREV as usize + 1);
+        assert_eq!(collected.first(), Some(&0));
+        assert_eq!(collected.last(), Some(&FSST12_NO_PREV));
+    }
+
+    #[test]
+    #[should_panic]
+    fn bitmap_set_out_of_range_panics() {
+        // Relies on debug_assert! firing under `cargo test`'s default debug build.
+        let mut map = CodesBitmap12::default();
+        map.set(FSST12_NO_PREV as usize + 1);
+    }
+
+    #[test]
+    fn builder_rejects_pht_collision() {
+        // "abcd" and "abce" share the same 3-byte prefix and hash to the same PHT slot.
+        let mut builder = CompressorBuilder12::new();
+        assert!(builder.insert(Symbol::from_slice(b"abcd\0\0\0\0"), 4));
+        assert!(!builder.insert(Symbol::from_slice(b"abce\0\0\0\0"), 4));
+        let compressor = builder.build();
+        let compressed = compressor.compress(b"abcd");
+        assert_eq!(compressed.len(), 2, "first inserted symbol should still match");
+    }
+
+    #[test]
+    fn train_produces_no_duplicate_symbols() {
+        let text = b"aababcabcdabcde";
+        let corpus: Vec<&[u8]> = std::iter::repeat_n(text.as_slice(), 100).collect();
+        let compressor = Compressor12::train(&corpus);
+        let symbols = compressor.symbol_table();
+        let lengths = compressor.symbol_lengths();
+
+        let one_byte: Vec<u8> = symbols
+            .iter()
+            .zip(lengths.iter())
+            .filter(|&(_, &len)| len == 1)
+            .map(|(sym, _)| sym.first_byte())
+            .collect();
+        assert_eq!(one_byte.len(), FSST12_RESERVED_CODES);
+        let mut one_byte_sorted = one_byte.clone();
+        one_byte_sorted.sort_unstable();
+        one_byte_sorted.dedup();
+        assert_eq!(
+            one_byte.len(),
+            one_byte_sorted.len(),
+            "duplicate 1-byte symbols in trained table"
+        );
+
+        let two_byte: Vec<u16> = symbols
+            .iter()
+            .zip(lengths.iter())
+            .filter(|&(_, &len)| len == 2)
+            .map(|(sym, _)| sym.first2())
+            .collect();
+        let mut two_byte_sorted = two_byte.clone();
+        two_byte_sorted.sort_unstable();
+        two_byte_sorted.dedup();
+        assert_eq!(
+            two_byte.len(),
+            two_byte_sorted.len(),
+            "duplicate 2-byte symbols in trained table"
+        );
+    }
+
+    #[test]
+    fn train_round_trip_on_multi_line_corpus() {
+        let lines: &[&[u8]] = &[
+            b"select * from users where email = 'alice@example.com'".as_slice(),
+            b"select * from users where email = 'bob@example.com'",
+            b"select * from orders where user_id = 42",
+            b"select * from orders where status = 'shipped'",
+            b"update users set last_login = now() where id = 7",
+        ];
+        let compressor = Compressor12::train(lines);
+        for line in lines {
+            let compressed = compressor.compress(line);
+            let decompressed = compressor.decompressor().decompress(&compressed);
+            assert_eq!(decompressed, *line);
+        }
+    }
+}

--- a/src/fsst12/builder.rs
+++ b/src/fsst12/builder.rs
@@ -649,7 +649,11 @@ mod tests {
         assert!(!builder.insert(Symbol::from_slice(b"abce\0\0\0\0"), 4));
         let compressor = builder.build();
         let compressed = compressor.compress(b"abcd");
-        assert_eq!(compressed.len(), 2, "first inserted symbol should still match");
+        assert_eq!(
+            compressed.len(),
+            2,
+            "first inserted symbol should still match"
+        );
     }
 
     #[test]

--- a/src/fsst12/builder.rs
+++ b/src/fsst12/builder.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     Symbol,
-    builder::{FSST_SAMPLETARGET, GENERATIONS, fsst_hash, make_sample},
+    builder::{FSST_SAMPLETARGET, fsst_hash, make_sample},
     compare_masked,
 };
 use rustc_hash::{FxBuildHasher, FxHashMap};
@@ -17,6 +17,18 @@ use super::{
     CODE12_LEN_SHIFT, CODE12_MASK, Compressor12, FSST12_MAX_LEARNED, FSST12_MAX_SYMBOLS,
     FSST12_RESERVED_CODES, FSST12_TWO_BYTE_TABLE_SIZE, lossy_pht::LossyPht12, pack_code12,
 };
+
+/// Sample fractions used per training generation.
+///
+/// Deliberately differs from cwida/fsst's FSST12-specific schedule (`[14, 52, 90, 128]`
+/// in `libfsst12.cpp`, four rounds), which is tuned for chaotic input like URLs / JSON.
+/// We reuse the five-round FSST8 schedule here because it compresses text materially
+/// better in our sweep (declaration / wikipedia / l_comment all degrade ~5-10% on the
+/// cwida schedule); the cwida schedule only wins on the `urls` corpus.
+#[cfg(not(miri))]
+const GENERATIONS12: [usize; 5] = [8usize, 38, 68, 98, 128];
+#[cfg(miri)]
+const GENERATIONS12: [usize; 3] = [8usize, 38, 128];
 
 /// Sentinel for `prev_code` before the first emission. Stored as the highest row of
 /// [`Counter12::pair_index`]; never appears in `code1_index`.
@@ -454,7 +466,7 @@ impl Compressor12 {
         let tot_size: usize = values.iter().map(|s| s.len()).sum();
         let sampled = tot_size >= FSST_SAMPLETARGET;
         let sample = make_sample(values, tot_size);
-        for sample_frac in GENERATIONS {
+        for sample_frac in GENERATIONS12 {
             for (i, line) in sample.iter().enumerate() {
                 if sample_frac < 128 && ((fsst_hash(i as u64) & 127) as usize) > sample_frac {
                     continue;

--- a/src/fsst12/lossy_pht.rs
+++ b/src/fsst12/lossy_pht.rs
@@ -6,10 +6,15 @@
 use crate::Symbol;
 use crate::builder::fsst_hash;
 
-/// 2048 × 16-byte entries = 32 KB. Matches the classic FSST PHT size. The full working
-/// set during compression (this table plus the 128 KB two-byte index plus up to 36 KB of
-/// symbol and length tables) does not fit in 32 KB L1d on common hardware; this size is
-/// inherited from the classic codec for parity rather than chosen by analysis here.
+/// 2048 × 16-byte entries = 32 KB. Matches the classic FSST PHT size.
+///
+/// Deliberately smaller than cwida/fsst's FSST12 PHT (`1 << 14` in `libfsst12.hpp`,
+/// 16384 entries / 256 KB). Our sweep showed cwida's size mostly hurts compression on
+/// text-like corpora (declaration / wikipedia / l_comment all degrade by 0.025–0.05),
+/// helps slightly on `urls` / `art_of_war`, and grows the working set out of L1d on
+/// common hardware. The full working set at this size (this table plus the 128 KB
+/// two-byte index plus up to 36 KB of symbol/length tables) still does not fit in 32 KB
+/// L1d, but doubling further makes the cache pressure worse without a clear win.
 pub(crate) const FSST12_PHT_SIZE: usize = 1 << 11;
 
 /// Code 0 is the identity code for byte `0x00`, which is length 1 and therefore never

--- a/src/fsst12/lossy_pht.rs
+++ b/src/fsst12/lossy_pht.rs
@@ -1,0 +1,89 @@
+//! Lossy perfect hash table for the FSST12 codec.
+//!
+//! Mirrors [`crate::lossy_pht`]: fixed-size, open-addressed, keyed by `fsst_hash` of the
+//! symbol's first 3 bytes. Stores 3+ byte symbols only.
+
+use crate::Symbol;
+use crate::builder::fsst_hash;
+
+/// 2048 × 16-byte entries = 32 KB. Matches the classic FSST PHT size. The full working
+/// set during compression (this table plus the 128 KB two-byte index plus up to 36 KB of
+/// symbol and length tables) does not fit in 32 KB L1d on common hardware; this size is
+/// inherited from the classic codec for parity rather than chosen by analysis here.
+pub(crate) const FSST12_PHT_SIZE: usize = 1 << 11;
+
+/// Code 0 is the identity code for byte `0x00`, which is length 1 and therefore never
+/// stored in the PHT, so it is safe to use as the empty-slot sentinel.
+const PHT_UNUSED: u16 = 0;
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub(crate) struct TableEntry12 {
+    pub(crate) symbol: Symbol,
+    /// [`PHT_UNUSED`] marks an empty slot.
+    pub(crate) code: u16,
+    /// `64 - 8 * len`, pre-computed for the compression loop's mask.
+    pub(crate) ignored_bits: u16,
+}
+
+assert_sizeof!(TableEntry12 => 16);
+
+impl TableEntry12 {
+    #[inline]
+    pub(crate) fn is_unused(&self) -> bool {
+        self.code == PHT_UNUSED
+    }
+}
+
+/// Insertions silently drop on collision, so callers must insert in decreasing-gain
+/// order.
+#[derive(Clone, Debug)]
+pub(crate) struct LossyPht12 {
+    slots: Vec<TableEntry12>,
+}
+
+impl LossyPht12 {
+    pub(crate) fn new() -> Self {
+        Self {
+            slots: vec![
+                TableEntry12 {
+                    symbol: Symbol::ZERO,
+                    code: PHT_UNUSED,
+                    ignored_bits: 64,
+                };
+                FSST12_PHT_SIZE
+            ],
+        }
+    }
+
+    /// Returns `false` if the slot was already occupied (existing entry kept).
+    pub(crate) fn insert(&mut self, symbol: Symbol, len: u8, code: u16) -> bool {
+        let prefix_3bytes = symbol.to_u64() & 0xFF_FF_FF;
+        let slot = fsst_hash(prefix_3bytes) as usize & (FSST12_PHT_SIZE - 1);
+        let entry = &mut self.slots[slot];
+        if !entry.is_unused() {
+            return false;
+        }
+        entry.symbol = symbol;
+        entry.code = code;
+        entry.ignored_bits = 64 - 8 * len as u16;
+        true
+    }
+
+    /// Returns the slot keyed by the first 3 bytes of `word`. Callers must verify the
+    /// result via [`TableEntry12::is_unused`] and a masked comparison against
+    /// `entry.symbol`.
+    #[inline]
+    pub(crate) fn lookup(&self, word: u64) -> TableEntry12 {
+        let prefix_3bytes = word & 0xFF_FF_FF;
+        let slot = fsst_hash(prefix_3bytes) as usize & (FSST12_PHT_SIZE - 1);
+        // SAFETY: slot is masked into [0, FSST12_PHT_SIZE).
+        unsafe { *self.slots.get_unchecked(slot) }
+    }
+
+    pub(crate) fn remove(&mut self, symbol: Symbol) {
+        let prefix_3bytes = symbol.to_u64() & 0xFF_FF_FF;
+        let slot = fsst_hash(prefix_3bytes) as usize & (FSST12_PHT_SIZE - 1);
+        self.slots[slot].code = PHT_UNUSED;
+    }
+}

--- a/src/fsst12/mod.rs
+++ b/src/fsst12/mod.rs
@@ -1,0 +1,729 @@
+//! FSST12: 12-bit-code variant of FSST.
+//!
+//! FSST12 is described in the [FastLanes File Format paper][fastlanes] and implemented in
+//! reference form by [cwida/fsst][cwida]. It differs from classic 8-bit FSST in three ways:
+//!
+//! - Codes are 12 bits wide, so the symbol table can hold up to 4096 entries.
+//! - The first 256 codes are reserved: code `i` always decodes to the single byte `i`.
+//!   These slots are not chosen by training and are present in every FSST12 table.
+//! - There is no escape mechanism. Because every byte already has a code, the compressor
+//!   always finds a match, and the decoder never branches on an escape sentinel.
+//!
+//! Each emitted code occupies 12 bits, so the encoded stream is bit-packed at 1.5 bytes
+//! per code. Single-byte fallbacks still cost more than the byte they encode (1.5× vs.
+//! 1×), but the penalty is lighter than FSST8's 2× escape cost.
+//!
+//! [fastlanes]: https://www.vldb.org/pvldb/vol18/p4629-afroozeh.pdf
+//! [cwida]: https://github.com/cwida/fsst
+
+use crate::{Symbol, advance_8byte_word, compare_masked};
+use std::mem::MaybeUninit;
+
+mod builder;
+mod lossy_pht;
+
+pub use builder::*;
+
+use lossy_pht::LossyPht12;
+
+/// Number of bits per code in FSST12.
+pub const FSST12_CODE_BITS: usize = 12;
+
+/// Maximum number of entries in an FSST12 symbol table.
+///
+/// Equal to `2^12 = 4096`, including the [`FSST12_RESERVED_CODES`] reserved single-byte
+/// slots.
+pub const FSST12_MAX_SYMBOLS: usize = 1 << FSST12_CODE_BITS;
+
+/// Number of code slots reserved for single-byte literal symbols.
+///
+/// Codes `0..256` always decode to the byte equal to their code value, regardless of any
+/// training that took place. Training only contributes symbols at codes `256..4096`.
+pub const FSST12_RESERVED_CODES: usize = 256;
+
+/// Maximum number of learned (length 2-8) symbols a training run may add.
+pub const FSST12_MAX_LEARNED: usize = FSST12_MAX_SYMBOLS - FSST12_RESERVED_CODES;
+
+pub(crate) const FSST12_TWO_BYTE_TABLE_SIZE: usize = 1 << 16;
+
+pub(crate) const CODE12_LEN_SHIFT: u32 = 12;
+pub(crate) const CODE12_MASK: u16 = (1 << CODE12_LEN_SHIFT) - 1;
+
+/// Bits `0..12` hold the code, bits `12..16` hold the length (1..=8).
+#[inline]
+pub(crate) fn pack_code12(code: u16, len: u8) -> u16 {
+    debug_assert!(code <= CODE12_MASK);
+    debug_assert!((1..=8).contains(&len));
+    ((len as u16) << CODE12_LEN_SHIFT) | code
+}
+
+/// An FSST12 compressor.
+///
+/// Compresses arbitrary byte sequences into a bit-packed stream of 12-bit codes. The
+/// first 256 codes always decode as the matching single byte, so every input has a code
+/// and no escape mechanism is needed.
+#[derive(Clone)]
+pub struct Compressor12 {
+    /// Entries 0..256 are reserved identity codes; entries 256.. are learned symbols of
+    /// length 2..=8.
+    pub(crate) symbols: Vec<Symbol>,
+    pub(crate) lengths: Vec<u8>,
+    /// Indexed by `u16` read of the input; each entry is `pack_code12(code, len)`. Every
+    /// slot is at least the identity code for the low input byte; 2-byte learned symbols
+    /// overwrite their respective slot.
+    pub(crate) codes_two_byte: Vec<u16>,
+    pub(crate) lossy_pht: LossyPht12,
+}
+
+impl Compressor12 {
+    /// Compress a byte slice into a bit-packed 12-bit code stream.
+    pub fn compress(&self, plaintext: &[u8]) -> Vec<u8> {
+        if plaintext.is_empty() {
+            return Vec::new();
+        }
+        // Worst case: every input byte resolves to a length-1 code, and the bit-packed
+        // output is 1.5 bytes per code. Round up and add 1 for the odd-code 2-byte tail.
+        let cap = (plaintext.len() * 3).div_ceil(2) + 1;
+        let mut out: Vec<u8> = Vec::with_capacity(cap);
+        // SAFETY: `cap` is at least the worst-case FSST12 output size.
+        unsafe { self.compress_into(plaintext, &mut out) };
+        out
+    }
+
+    /// Greedy compression into `out`. On return, `out` is truncated to the actual encoded
+    /// length. FSST12 analogue of [`crate::Compressor::compress_into`].
+    ///
+    /// # Safety
+    ///
+    /// `out.capacity()` must be at least `ceil(plaintext.len() * 3 / 2) + 1`. The function
+    /// writes raw bytes into the spare capacity and then calls `set_len`, so calling with
+    /// undersized capacity is undefined behaviour.
+    ///
+    /// ```
+    /// use fsst::fsst12::{Compressor12, CompressorBuilder12};
+    /// use fsst::Symbol;
+    ///
+    /// let mut builder = CompressorBuilder12::new();
+    /// assert!(builder.insert(Symbol::from_slice(b"abcdefgh"), 8));
+    /// let compressor = builder.build();
+    ///
+    /// let plaintext: &[u8] = b"abcdefghabcdefgh";
+    /// let mut buf = Vec::with_capacity(plaintext.len() * 3 / 2 + 2);
+    /// // SAFETY: `buf` capacity exceeds the worst-case FSST12 output size.
+    /// unsafe { compressor.compress_into(plaintext, &mut buf) };
+    /// assert_eq!(compressor.decompressor().decompress(&buf), plaintext);
+    /// ```
+    pub unsafe fn compress_into(&self, plaintext: &[u8], out: &mut Vec<u8>) {
+        // SAFETY: pointer arithmetic is guarded by either the fast-loop precondition
+        // (`in_ptr + 8 <= in_end`) or by reading from a zero-padded `last_word` in the
+        // tail. Output writes are bounded by the caller-asserted capacity.
+        let written = unsafe {
+            let in_begin = plaintext.as_ptr();
+            let in_end = in_begin.add(plaintext.len());
+            let mut in_ptr = in_begin;
+            let out_begin = out.as_mut_ptr();
+            let mut out_ptr = out_begin;
+
+            // When `have_pending` is true, `pending` holds the previous code's 12 bits in
+            // its low 12. The next code OR's into bits 12..24 to form a 3-byte triple.
+            let mut pending: u32 = 0;
+            let mut have_pending = false;
+
+            macro_rules! emit_code {
+                ($code:expr) => {{
+                    let code = $code as u32;
+                    if have_pending {
+                        let packed = pending | (code << CODE12_LEN_SHIFT);
+                        out_ptr.write(packed as u8);
+                        out_ptr.add(1).write((packed >> 8) as u8);
+                        out_ptr.add(2).write((packed >> 16) as u8);
+                        out_ptr = out_ptr.add(3);
+                        have_pending = false;
+                    } else {
+                        pending = code;
+                        have_pending = true;
+                    }
+                }};
+            }
+
+            // ≥ 8 input bytes: unaligned u64 reads are safe, so the match-finder can
+            // skip the `remaining` check.
+            if plaintext.len() >= 8 {
+                let in_end_sub8 = in_end.sub(8);
+                while (in_ptr as usize) <= (in_end_sub8 as usize) {
+                    let word = in_ptr.cast::<u64>().read_unaligned();
+                    let (code, advance) = self.compress_word_full(word);
+                    emit_code!(code);
+                    in_ptr = in_ptr.add(advance);
+                }
+            }
+
+            // < 8 bytes left: read into a zero-padded word so we never dereference past
+            // `in_end`.
+            let mut remaining = in_end.offset_from(in_ptr) as usize;
+            if remaining > 0 {
+                let mut bytes = [0u8; 8];
+                std::ptr::copy_nonoverlapping(in_ptr, bytes.as_mut_ptr(), remaining);
+                let mut last_word = u64::from_le_bytes(bytes);
+                while remaining > 0 {
+                    let (code, advance) = self.compress_word(last_word, remaining);
+                    emit_code!(code);
+                    remaining -= advance;
+                    last_word = advance_8byte_word(last_word, advance);
+                }
+            }
+
+            // Odd trailing code: 2 bytes with the high nibble zero-padded.
+            if have_pending {
+                out_ptr.write(pending as u8);
+                out_ptr.add(1).write(((pending >> 8) & 0x0F) as u8);
+                out_ptr = out_ptr.add(2);
+            }
+
+            out_ptr.offset_from(out_begin) as usize
+        };
+
+        // SAFETY: the unsafe block above wrote `written` bytes into `out`'s spare capacity.
+        unsafe { out.set_len(written) };
+    }
+
+    /// Assumes ≥ 8 input bytes are valid past `word`'s first byte. PHT entry lengths
+    /// are bounded by the PHT invariant (3..=8), so no `remaining` check is needed.
+    #[inline]
+    fn compress_word_full(&self, word: u64) -> (u16, usize) {
+        // SAFETY: codes_two_byte has FSST12_TWO_BYTE_TABLE_SIZE = 65536 entries, and
+        // `word as u16 as usize` is always in [0, 65535].
+        let two_byte = unsafe {
+            *self
+                .codes_two_byte
+                .get_unchecked((word as u16) as usize)
+        };
+        let two_byte_code = two_byte & CODE12_MASK;
+        let two_byte_len = (two_byte >> CODE12_LEN_SHIFT) as usize;
+
+        let entry = self.lossy_pht.lookup(word);
+        if !entry.is_unused() && compare_masked(word, entry.symbol.to_u64(), entry.ignored_bits)
+        {
+            let entry_len = ((64 - entry.ignored_bits) >> 3) as usize;
+            return (entry.code, entry_len);
+        }
+        (two_byte_code, two_byte_len)
+    }
+
+    /// `remaining` is the number of real bytes in `word` (1..=7); padding must not match.
+    #[inline]
+    fn compress_word(&self, word: u64, remaining: usize) -> (u16, usize) {
+        if remaining >= 2 {
+            // SAFETY: `word as u16 as usize` is always in [0, 65535].
+            let two_byte = unsafe {
+                *self
+                    .codes_two_byte
+                    .get_unchecked((word as u16) as usize)
+            };
+            let two_byte_code = two_byte & CODE12_MASK;
+            let two_byte_len = (two_byte >> CODE12_LEN_SHIFT) as usize;
+
+            if remaining >= 3 {
+                let entry = self.lossy_pht.lookup(word);
+                if !entry.is_unused() {
+                    let entry_len = ((64 - entry.ignored_bits) >> 3) as usize;
+                    if entry_len <= remaining
+                        && compare_masked(word, entry.symbol.to_u64(), entry.ignored_bits)
+                    {
+                        return (entry.code, entry_len);
+                    }
+                }
+            }
+
+            (two_byte_code, two_byte_len)
+        } else {
+            ((word & 0xFF) as u16, 1)
+        }
+    }
+
+    /// Compress many lines in bulk. FSST12 analogue of [`crate::Compressor::compress_bulk`].
+    pub fn compress_bulk(&self, lines: &[&[u8]]) -> Vec<Vec<u8>> {
+        lines.iter().map(|line| self.compress(line)).collect()
+    }
+
+    /// Borrow a [`Decompressor12`] view over this compressor's symbol table.
+    pub fn decompressor(&self) -> Decompressor12<'_> {
+        Decompressor12::new(&self.symbols, &self.lengths)
+    }
+
+    /// The first 256 entries are the reserved single-byte literals.
+    pub fn symbol_table(&self) -> &[Symbol] {
+        &self.symbols
+    }
+
+    /// Length of each symbol in [`symbol_table`][Self::symbol_table]. Values in 1..=8.
+    pub fn symbol_lengths(&self) -> &[u8] {
+        &self.lengths
+    }
+}
+
+/// Decompressor for FSST12-compressed byte streams.
+#[derive(Clone)]
+pub struct Decompressor12<'a> {
+    pub(crate) symbols: &'a [Symbol],
+    pub(crate) lengths: &'a [u8],
+}
+
+impl<'a> Decompressor12<'a> {
+    /// Construct a decompressor from a symbol table and matching length slice.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `symbols` and `lengths` have different lengths, if `symbols.len()`
+    /// is below [`FSST12_RESERVED_CODES`] or exceeds [`FSST12_MAX_SYMBOLS`], or if any
+    /// of the first 256 entries are not the identity single-byte codes required by FSST12.
+    pub fn new(symbols: &'a [Symbol], lengths: &'a [u8]) -> Self {
+        assert_eq!(
+            symbols.len(),
+            lengths.len(),
+            "symbol table and length table must be the same size"
+        );
+        assert!(
+            symbols.len() >= FSST12_RESERVED_CODES,
+            "FSST12 table must contain the {FSST12_RESERVED_CODES} reserved identity codes"
+        );
+        assert!(
+            symbols.len() <= FSST12_MAX_SYMBOLS,
+            "FSST12 table cannot exceed {FSST12_MAX_SYMBOLS} entries"
+        );
+        // Full u64 must equal code so the SWAR fast loop's 8-byte unaligned writes
+        // don't smear garbage into the output buffer's slack region.
+        for (code, (symbol, &length)) in symbols
+            .iter()
+            .zip(lengths.iter())
+            .enumerate()
+            .take(FSST12_RESERVED_CODES)
+        {
+            assert!(
+                length == 1 && symbol.to_u64() == code as u64,
+                "FSST12 code {code} must be the identity single-byte symbol"
+            );
+        }
+        Self { symbols, lengths }
+    }
+
+    /// The symbol table this decompressor was constructed with.
+    pub fn symbol_table(&self) -> &[Symbol] {
+        self.symbols
+    }
+
+    /// The length table this decompressor was constructed with.
+    pub fn symbol_lengths(&self) -> &[u8] {
+        self.lengths
+    }
+
+    /// Upper bound on the decompressed size: `n_codes <= ceil(compressed.len() * 8 / 12)`
+    /// and each code is at most 8 bytes.
+    pub fn max_decompression_capacity(&self, compressed: &[u8]) -> usize {
+        compressed.len() * 16 / 3 + 8
+    }
+
+    /// Decompress a bit-packed 12-bit code stream into a caller-provided buffer, and
+    /// return the number of bytes written. The buffer must be at least
+    /// [`Self::max_decompression_capacity`] long for the SWAR fast path; smaller buffers
+    /// fall back to a byte-by-byte tail.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `compressed.len() % 3 == 1` (not a valid FSST12 encoded length), or if
+    /// `decoded` is too small to hold the decoded output.
+    ///
+    /// ```
+    /// use fsst::fsst12::{Compressor12, CompressorBuilder12};
+    /// use fsst::Symbol;
+    ///
+    /// let mut builder = CompressorBuilder12::new();
+    /// assert!(builder.insert(Symbol::from_slice(b"abcdefgh"), 8));
+    /// let compressor = builder.build();
+    /// let decompressor = compressor.decompressor();
+    ///
+    /// let compressed = compressor.compress(b"abcdefgh");
+    /// let mut out = Vec::with_capacity(decompressor.max_decompression_capacity(&compressed));
+    /// let len = decompressor.decompress_into(&compressed, out.spare_capacity_mut());
+    /// // SAFETY: decompress_into initializes the first `len` bytes.
+    /// unsafe { out.set_len(len) };
+    /// assert_eq!(&out, b"abcdefgh");
+    /// ```
+    pub fn decompress_into(
+        &self,
+        compressed: &[u8],
+        decoded: &mut [MaybeUninit<u8>],
+    ) -> usize {
+        if compressed.is_empty() {
+            return 0;
+        }
+
+        // SAFETY: the unsafe block uses raw pointer arithmetic but checks every write
+        // either by reserving 16 bytes of slack in the fast loop or by guarded byte-wise
+        // copies in the tail.
+        unsafe {
+            let in_begin = compressed.as_ptr();
+            let in_end = in_begin.add(compressed.len());
+            let mut in_ptr = in_begin;
+
+            let out_begin: *mut u8 = decoded.as_mut_ptr().cast();
+            let out_end = out_begin.add(decoded.len());
+            let mut out_ptr = out_begin;
+
+            // Read 4 input bytes via u32 (consuming 3, peeking 1 for the next iter), emit
+            // 2 codes via unaligned u64 writes. The 16-byte output slack lets back-to-back
+            // length-1 symbols over-write safely.
+            while in_ptr.add(4) <= in_end && out_ptr.add(16) <= out_end {
+                let raw = in_ptr.cast::<u32>().read_unaligned();
+                in_ptr = in_ptr.add(3);
+
+                let code_a = (raw & CODE12_MASK as u32) as usize;
+                let code_b = ((raw >> CODE12_LEN_SHIFT) & CODE12_MASK as u32) as usize;
+
+                let sym_a = self.symbols.get_unchecked(code_a).to_u64();
+                let len_a = *self.lengths.get_unchecked(code_a) as usize;
+                out_ptr.cast::<u64>().write_unaligned(sym_a);
+                out_ptr = out_ptr.add(len_a);
+
+                let sym_b = self.symbols.get_unchecked(code_b).to_u64();
+                let len_b = *self.lengths.get_unchecked(code_b) as usize;
+                out_ptr.cast::<u64>().write_unaligned(sym_b);
+                out_ptr = out_ptr.add(len_b);
+            }
+
+            // Byte-wise tail: used both when input runs short (≤ 3 bytes left) and when
+            // output runs out of fast-loop slack.
+            while in_ptr.add(3) <= in_end {
+                let raw = (*in_ptr as u32)
+                    | ((*in_ptr.add(1) as u32) << 8)
+                    | ((*in_ptr.add(2) as u32) << 16);
+                in_ptr = in_ptr.add(3);
+                let code_a = (raw & CODE12_MASK as u32) as usize;
+                let code_b = ((raw >> CODE12_LEN_SHIFT) & CODE12_MASK as u32) as usize;
+
+                let len_a = *self.lengths.get_unchecked(code_a) as usize;
+                assert!(
+                    out_end.offset_from(out_ptr) >= len_a as isize,
+                    "decoded buffer too small for FSST12 decompression"
+                );
+                let sym_a = self.symbols.get_unchecked(code_a).to_u64().to_le_bytes();
+                std::ptr::copy_nonoverlapping(sym_a.as_ptr(), out_ptr, len_a);
+                out_ptr = out_ptr.add(len_a);
+
+                let len_b = *self.lengths.get_unchecked(code_b) as usize;
+                assert!(
+                    out_end.offset_from(out_ptr) >= len_b as isize,
+                    "decoded buffer too small for FSST12 decompression"
+                );
+                let sym_b = self.symbols.get_unchecked(code_b).to_u64().to_le_bytes();
+                std::ptr::copy_nonoverlapping(sym_b.as_ptr(), out_ptr, len_b);
+                out_ptr = out_ptr.add(len_b);
+            }
+
+            // 0 bytes = clean end; 2 bytes = trailing odd code; 1 byte = invalid.
+            let remaining = in_end.offset_from(in_ptr) as usize;
+            match remaining {
+                0 => {}
+                2 => {
+                    let raw = (*in_ptr as u16) | ((*in_ptr.add(1) as u16) << 8);
+                    let code = (raw & CODE12_MASK) as usize;
+                    let len = *self.lengths.get_unchecked(code) as usize;
+                    assert!(
+                        out_end.offset_from(out_ptr) >= len as isize,
+                        "decoded buffer too small for FSST12 decompression"
+                    );
+                    let sym = self.symbols.get_unchecked(code).to_u64().to_le_bytes();
+                    std::ptr::copy_nonoverlapping(sym.as_ptr(), out_ptr, len);
+                    out_ptr = out_ptr.add(len);
+                }
+                _ => panic!("invalid FSST12 packed length"),
+            }
+
+            out_ptr.offset_from(out_begin) as usize
+        }
+    }
+
+    /// Decompress a bit-packed 12-bit code stream into a fresh `Vec`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `compressed.len() % 3 == 1`, which cannot be produced by a valid
+    /// [`Compressor12::compress`] output (valid encoded lengths are `0 mod 3` for pairs
+    /// of codes, or `2 mod 3` for an odd code count).
+    pub fn decompress(&self, compressed: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.max_decompression_capacity(compressed));
+        let len = self.decompress_into(compressed, out.spare_capacity_mut());
+        // SAFETY: decompress_into initialized the first `len` bytes of `out`'s spare capacity.
+        unsafe { out.set_len(len) };
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_round_trip() {
+        let compressor = CompressorBuilder12::new().build();
+        let compressed = compressor.compress(b"");
+        assert!(compressed.is_empty());
+        let decompressed = compressor.decompressor().decompress(&compressed);
+        assert!(decompressed.is_empty());
+    }
+
+    #[test]
+    fn single_byte_packs_to_two_bytes_with_padding() {
+        // With no learned symbols, byte 0x12 maps to identity code 0x012.
+        // One code occupies 12 bits, padded to 2 bytes; high nibble of byte 1 is zero.
+        let compressor = CompressorBuilder12::new().build();
+        let compressed = compressor.compress(&[0x12]);
+        assert_eq!(compressed, vec![0x12, 0x00]);
+    }
+
+    #[test]
+    fn two_bytes_pack_into_three_bytes_le() {
+        // Codes [0x012, 0x034] pack as u24 = 0x012 | (0x034 << 12) = 0x034012,
+        // little-endian: [0x12, 0x40, 0x03].
+        let compressor = CompressorBuilder12::new().build();
+        let compressed = compressor.compress(&[0x12, 0x34]);
+        assert_eq!(compressed, vec![0x12, 0x40, 0x03]);
+    }
+
+    #[test]
+    fn identity_round_trip_even_length() {
+        let compressor = CompressorBuilder12::new().build();
+        let plaintext: &[u8] = b"abcdef";
+        let compressed = compressor.compress(plaintext);
+        let decompressed = compressor.decompressor().decompress(&compressed);
+        assert_eq!(decompressed, plaintext);
+    }
+
+    #[test]
+    fn identity_round_trip_odd_length() {
+        // Odd byte count exercises the trailing-padded-code path.
+        let compressor = CompressorBuilder12::new().build();
+        let plaintext: &[u8] = b"abcdefg";
+        let compressed = compressor.compress(plaintext);
+        let decompressed = compressor.decompressor().decompress(&compressed);
+        assert_eq!(decompressed, plaintext);
+    }
+
+    #[test]
+    fn two_byte_learned_symbol_emits_single_code() {
+        // "ab" gets code 256 = 0x100, packed into 2 bytes: low byte 0x00, high nibble 0x01.
+        let mut builder = CompressorBuilder12::new();
+        assert!(builder.insert(Symbol::from_slice(&[b'a', b'b', 0, 0, 0, 0, 0, 0]), 2));
+        let compressor = builder.build();
+        let compressed = compressor.compress(b"ab");
+        assert_eq!(compressed, vec![0x00, 0x01]);
+
+        let decompressed = compressor.decompressor().decompress(&compressed);
+        assert_eq!(decompressed, b"ab");
+    }
+
+    #[test]
+    fn learned_symbol_prefers_longer_match() {
+        // With both 2-byte "ab" and 3-byte "abc" in the table, "abc" must emit 1 code.
+        let mut builder = CompressorBuilder12::new();
+        assert!(builder.insert(Symbol::from_slice(&[b'a', b'b', 0, 0, 0, 0, 0, 0]), 2));
+        assert!(builder.insert(Symbol::from_slice(&[b'a', b'b', b'c', 0, 0, 0, 0, 0]), 3));
+        let compressor = builder.build();
+        let compressed = compressor.compress(b"abc");
+        // Single code 257 = 0x101: low 8 bits = 0x01, high nibble = 0x01.
+        assert_eq!(compressed, vec![0x01, 0x01]);
+
+        let decompressed = compressor.decompressor().decompress(&compressed);
+        assert_eq!(decompressed, b"abc");
+    }
+
+    #[test]
+    fn learned_symbol_eight_byte_round_trip() {
+        let mut builder = CompressorBuilder12::new();
+        assert!(builder.insert(Symbol::from_slice(b"abcdefgh"), 8));
+        let compressor = builder.build();
+        let plaintext: &[u8] = b"abcdefghZabcdefgh";
+        let compressed = compressor.compress(plaintext);
+        let decompressed = compressor.decompressor().decompress(&compressed);
+        assert_eq!(decompressed, plaintext);
+        // 3 codes (8-byte sym, 'Z', 8-byte sym) packed into 5 bytes.
+        assert_eq!(compressed.len(), 5);
+    }
+
+    #[test]
+    fn longer_pht_match_wins_over_two_byte_match() {
+        // "ab" (2-byte) and "abcdef" (6-byte) share the same prefix; "abcdef" wins.
+        let mut builder = CompressorBuilder12::new();
+        assert!(builder.insert(Symbol::from_slice(b"ab\0\0\0\0\0\0"), 2));
+        assert!(builder.insert(Symbol::from_slice(b"abcdef\0\0"), 6));
+        let compressor = builder.build();
+        let compressed = compressor.compress(b"abcdef");
+        // Code 257 (= 0x101). Single code, 2 bytes.
+        assert_eq!(compressed, vec![0x01, 0x01]);
+        let decompressed = compressor.decompressor().decompress(&compressed);
+        assert_eq!(decompressed, b"abcdef");
+    }
+
+    #[test]
+    fn symbol_match_at_end_of_input_no_over_read() {
+        // An 8-byte symbol matches the last 8 bytes of a 9-byte input, with no padding
+        // for the encoder to falsely match into.
+        let mut builder = CompressorBuilder12::new();
+        assert!(builder.insert(Symbol::from_slice(b"abcdefgh"), 8));
+        let compressor = builder.build();
+        let plaintext: &[u8] = b"Xabcdefgh";
+        let compressed = compressor.compress(plaintext);
+        let decompressed = compressor.decompressor().decompress(&compressed);
+        assert_eq!(decompressed, plaintext);
+    }
+
+    #[test]
+    fn long_identity_round_trip() {
+        // 257 bytes: enough for the SWAR body plus an odd-length tail.
+        let compressor = CompressorBuilder12::new().build();
+        let plaintext: Vec<u8> = (0..257u32).map(|i| (i & 0xFF) as u8).collect();
+        let compressed = compressor.compress(&plaintext);
+        let decompressed = compressor.decompressor().decompress(&compressed);
+        assert_eq!(decompressed, plaintext);
+    }
+
+    #[test]
+    fn long_mixed_round_trip() {
+        let mut builder = CompressorBuilder12::new();
+        assert!(builder.insert(Symbol::from_slice(b"ab\0\0\0\0\0\0"), 2));
+        assert!(builder.insert(Symbol::from_slice(b"abc\0\0\0\0\0"), 3));
+        assert!(builder.insert(Symbol::from_slice(b"the quic"), 8));
+        let compressor = builder.build();
+        let mut plaintext = Vec::with_capacity(256);
+        for _ in 0..20 {
+            plaintext.extend_from_slice(b"the quick abc ab xyz ");
+        }
+        let compressed = compressor.compress(&plaintext);
+        let decompressed = compressor.decompressor().decompress(&compressed);
+        assert_eq!(decompressed, plaintext);
+    }
+
+    #[test]
+    fn compress_fast_loop_boundary_sizes() {
+        // Spans the 8-byte fast/tail-loop threshold; includes a PHT and a 2-byte symbol.
+        let mut builder = CompressorBuilder12::new();
+        assert!(builder.insert(Symbol::from_slice(b"abcdefgh"), 8));
+        assert!(builder.insert(Symbol::from_slice(b"xy\0\0\0\0\0\0"), 2));
+        let compressor = builder.build();
+
+        let base = b"abcdefgh_xy_abcdefgh_xy_";
+        for n in [1usize, 2, 3, 7, 8, 9, 15, 16, 17, 24, 25, 31, 32, 33] {
+            let plaintext: Vec<u8> = base.iter().copied().cycle().take(n).collect();
+            let compressed = compressor.compress(&plaintext);
+            let decompressed = compressor.decompressor().decompress(&compressed);
+            assert_eq!(decompressed, plaintext, "round-trip failed at n={}", n);
+        }
+    }
+
+    #[test]
+    fn compress_no_learned_symbols_round_trips_at_8_byte_boundary() {
+        // Every byte is a length-1 identity code: the fast loop emits one code per iter.
+        let compressor = CompressorBuilder12::new().build();
+        for n in [7usize, 8, 9, 15, 16, 17, 64, 65] {
+            let plaintext: Vec<u8> = (0..n as u32).map(|i| (i & 0xFF) as u8).collect();
+            let compressed = compressor.compress(&plaintext);
+            // Each code is 12 bits → ceil(n * 12 / 8) bytes.
+            assert_eq!(
+                compressed.len(),
+                n.div_ceil(2) * 3 - if n % 2 == 1 { 1 } else { 0 },
+                "compressed length mismatch at n={}",
+                n
+            );
+            let decompressed = compressor.decompressor().decompress(&compressed);
+            assert_eq!(decompressed, plaintext, "round-trip failed at n={}", n);
+        }
+    }
+
+    #[test]
+    fn decompress_into_exact_capacity() {
+        // With exactly the uncompressed length, decompress_into must finish via the safe
+        // byte-by-byte tail rather than the SWAR over-writing past the buffer end.
+        let mut builder = CompressorBuilder12::new();
+        assert!(builder.insert(Symbol::from_slice(b"aaaaaaaa"), 8));
+        let compressor = builder.build();
+        let plaintext = vec![b'a'; 10_000];
+        let compressed = compressor.compress(&plaintext);
+
+        let decompressor = compressor.decompressor();
+        let mut decompressed: Vec<u8> = Vec::with_capacity(plaintext.len());
+        let len =
+            decompressor.decompress_into(&compressed, decompressed.spare_capacity_mut());
+        // SAFETY: decompress_into initialized the first `len` bytes.
+        unsafe { decompressed.set_len(len) };
+        assert_eq!(decompressed, plaintext);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid FSST12 packed length")]
+    fn decompress_into_invalid_packed_length_panics() {
+        // Valid FSST12 lengths are `0 mod 3` or `2 mod 3`; a 1-byte buffer is neither.
+        let compressor = CompressorBuilder12::new().build();
+        let decompressor = compressor.decompressor();
+        let mut out: Vec<u8> = Vec::with_capacity(8);
+        decompressor.decompress_into(&[0x12], out.spare_capacity_mut());
+    }
+
+    #[test]
+    fn decompressor_getters_expose_underlying_tables() {
+        let mut builder = CompressorBuilder12::new();
+        assert!(builder.insert(Symbol::from_slice(b"abcdefgh"), 8));
+        let compressor = builder.build();
+        let decompressor = compressor.decompressor();
+        assert_eq!(decompressor.symbol_table(), compressor.symbol_table());
+        assert_eq!(decompressor.symbol_lengths(), compressor.symbol_lengths());
+    }
+
+    #[test]
+    fn compress_bulk_round_trips_each_line() {
+        let mut builder = CompressorBuilder12::new();
+        assert!(builder.insert(Symbol::from_slice(b"abcdefgh"), 8));
+        let compressor = builder.build();
+        let lines: [&[u8]; 3] = [b"abcdefgh".as_slice(), b"hello", b""];
+        let bulk = compressor.compress_bulk(&lines);
+        assert_eq!(bulk.len(), 3);
+        let decompressor = compressor.decompressor();
+        for (line, encoded) in lines.iter().zip(bulk.iter()) {
+            assert_eq!(decompressor.decompress(encoded), *line);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "must be the identity single-byte symbol")]
+    fn decompressor_new_rejects_non_identity_reserved_code() {
+        let mut symbols: Vec<Symbol> = (0..FSST12_RESERVED_CODES)
+            .map(|code| Symbol::from_u8(code as u8))
+            .collect();
+        let mut lengths = vec![1u8; FSST12_RESERVED_CODES];
+        // Corrupt one reserved slot.
+        symbols[42] = Symbol::from_slice(b"corrupt!");
+        lengths[42] = 8;
+        Decompressor12::new(&symbols, &lengths);
+    }
+
+    #[test]
+    #[should_panic(expected = "reserved identity codes")]
+    fn decompressor_new_rejects_table_below_reserved_size() {
+        let symbols = vec![Symbol::ZERO; FSST12_RESERVED_CODES - 1];
+        let lengths = vec![1u8; FSST12_RESERVED_CODES - 1];
+        Decompressor12::new(&symbols, &lengths);
+    }
+
+    #[test]
+    #[should_panic(expected = "decoded buffer too small")]
+    fn decompress_into_buffer_too_small_panics() {
+        let mut builder = CompressorBuilder12::new();
+        assert!(builder.insert(Symbol::from_slice(b"aaaaaaaa"), 8));
+        let compressor = builder.build();
+        let plaintext = vec![b'a'; 1_000];
+        let compressed = compressor.compress(&plaintext);
+        let decompressor = compressor.decompressor();
+
+        let mut undersized: Vec<u8> = Vec::with_capacity(plaintext.len() / 2);
+        decompressor.decompress_into(&compressed, undersized.spare_capacity_mut());
+    }
+}

--- a/src/fsst12/mod.rs
+++ b/src/fsst12/mod.rs
@@ -1,7 +1,8 @@
 //! FSST12: 12-bit-code variant of FSST.
 //!
-//! FSST12 is described in the [FastLanes File Format paper][fastlanes] and implemented in
-//! reference form by [cwida/fsst][cwida]. It differs from classic 8-bit FSST in three ways:
+//! Ported from the [cwida/fsst][cwida] reference implementation by the original FSST
+//! authors; also mentioned in the [FastLanes File Format paper][fastlanes]. It differs
+//! from classic 8-bit FSST in three ways:
 //!
 //! - Codes are 12 bits wide, so the symbol table can hold up to 4096 entries.
 //! - The first 256 codes are reserved: code `i` always decodes to the single byte `i`.
@@ -13,8 +14,8 @@
 //! per code. Single-byte fallbacks still cost more than the byte they encode (1.5× vs.
 //! 1×), but the penalty is lighter than FSST8's 2× escape cost.
 //!
-//! [fastlanes]: https://www.vldb.org/pvldb/vol18/p4629-afroozeh.pdf
 //! [cwida]: https://github.com/cwida/fsst
+//! [fastlanes]: https://www.vldb.org/pvldb/vol18/p4629-afroozeh.pdf
 
 use crate::{Symbol, advance_8byte_word, compare_masked};
 use std::mem::MaybeUninit;

--- a/src/fsst12/mod.rs
+++ b/src/fsst12/mod.rs
@@ -194,17 +194,12 @@ impl Compressor12 {
     fn compress_word_full(&self, word: u64) -> (u16, usize) {
         // SAFETY: codes_two_byte has FSST12_TWO_BYTE_TABLE_SIZE = 65536 entries, and
         // `word as u16 as usize` is always in [0, 65535].
-        let two_byte = unsafe {
-            *self
-                .codes_two_byte
-                .get_unchecked((word as u16) as usize)
-        };
+        let two_byte = unsafe { *self.codes_two_byte.get_unchecked((word as u16) as usize) };
         let two_byte_code = two_byte & CODE12_MASK;
         let two_byte_len = (two_byte >> CODE12_LEN_SHIFT) as usize;
 
         let entry = self.lossy_pht.lookup(word);
-        if !entry.is_unused() && compare_masked(word, entry.symbol.to_u64(), entry.ignored_bits)
-        {
+        if !entry.is_unused() && compare_masked(word, entry.symbol.to_u64(), entry.ignored_bits) {
             let entry_len = ((64 - entry.ignored_bits) >> 3) as usize;
             return (entry.code, entry_len);
         }
@@ -216,11 +211,7 @@ impl Compressor12 {
     fn compress_word(&self, word: u64, remaining: usize) -> (u16, usize) {
         if remaining >= 2 {
             // SAFETY: `word as u16 as usize` is always in [0, 65535].
-            let two_byte = unsafe {
-                *self
-                    .codes_two_byte
-                    .get_unchecked((word as u16) as usize)
-            };
+            let two_byte = unsafe { *self.codes_two_byte.get_unchecked((word as u16) as usize) };
             let two_byte_code = two_byte & CODE12_MASK;
             let two_byte_len = (two_byte >> CODE12_LEN_SHIFT) as usize;
 
@@ -350,11 +341,7 @@ impl<'a> Decompressor12<'a> {
     /// unsafe { out.set_len(len) };
     /// assert_eq!(&out, b"abcdefgh");
     /// ```
-    pub fn decompress_into(
-        &self,
-        compressed: &[u8],
-        decoded: &mut [MaybeUninit<u8>],
-    ) -> usize {
+    pub fn decompress_into(&self, compressed: &[u8], decoded: &mut [MaybeUninit<u8>]) -> usize {
         if compressed.is_empty() {
             return 0;
         }
@@ -652,8 +639,7 @@ mod tests {
 
         let decompressor = compressor.decompressor();
         let mut decompressed: Vec<u8> = Vec::with_capacity(plaintext.len());
-        let len =
-            decompressor.decompress_into(&compressed, decompressed.spare_capacity_mut());
+        let len = decompressor.decompress_into(&compressed, decompressed.spare_capacity_mut());
         // SAFETY: decompress_into initialized the first `len` bytes.
         unsafe { decompressed.set_len(len) };
         assert_eq!(decompressed, plaintext);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use std::fmt::{Debug, Formatter};
 use std::mem::MaybeUninit;
 
 mod builder;
+pub mod fsst12;
 mod lossy_pht;
 
 pub use builder::*;

--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -2,6 +2,7 @@
 
 #![cfg(test)]
 
+use fsst::fsst12::{Compressor12, CompressorBuilder12};
 use fsst::{Compressor, CompressorBuilder, Symbol};
 
 static PREAMBLE: &str = r#"
@@ -163,4 +164,79 @@ fn test_pruning_small_input() {
 
     let compressed = compressor.compress(&corpus);
     assert_eq!(compressor.decompressor().decompress(&compressed), corpus);
+}
+
+// --- FSST12 ---
+
+#[test]
+fn fsst12_round_trip_preamble() {
+    let trained = Compressor12::train(&[PREAMBLE.as_bytes()]);
+    let compressed = trained.compress(PREAMBLE.as_bytes());
+    let decompressed = trained.decompressor().decompress(&compressed);
+    assert_eq!(decompressed, PREAMBLE.as_bytes());
+}
+
+#[test]
+fn fsst12_round_trip_declaration() {
+    let trained = Compressor12::train(&[DECLARATION.as_bytes()]);
+    let compressed = trained.compress(DECLARATION.as_bytes());
+    let decompressed = trained.decompressor().decompress(&compressed);
+    assert_eq!(decompressed, DECLARATION.as_bytes());
+    assert!(
+        compressed.len() < DECLARATION.len(),
+        "expected compressed ({}) < raw ({})",
+        compressed.len(),
+        DECLARATION.len(),
+    );
+}
+
+#[test]
+fn fsst12_train_on_empty_still_round_trips() {
+    let trained = Compressor12::train(&[]);
+    let input = b"the quick brown fox jumped over the lazy dog";
+    let compressed = trained.compress(input);
+    assert_eq!(trained.decompressor().decompress(&compressed), input);
+}
+
+#[test]
+fn fsst12_zero_byte_round_trip() {
+    let training_data: Vec<u8> = vec![0, 1, 2, 3, 4, 0];
+    let trained = Compressor12::train(&[training_data.as_slice()]);
+    let compressed = trained.compress(&[4, 0]);
+    assert_eq!(trained.decompressor().decompress(&compressed), &[4, 0]);
+}
+
+#[test]
+fn fsst12_chinese() {
+    let trained = Compressor12::train(&[ART_OF_WAR.as_bytes()]);
+    let compressed = trained.compress(ART_OF_WAR.as_bytes());
+    assert_eq!(
+        trained.decompressor().decompress(&compressed),
+        ART_OF_WAR.as_bytes()
+    );
+}
+
+#[cfg_attr(miri, ignore)]
+#[test]
+fn fsst12_large() {
+    let corpus: Vec<u8> = DECLARATION.bytes().cycle().take(10_240).collect();
+    let trained = Compressor12::train(&[corpus.as_slice()]);
+    let massive: Vec<u8> = DECLARATION
+        .bytes()
+        .cycle()
+        .take(16 * 1_024 * 1_024)
+        .collect();
+
+    let compressed = trained.compress(&massive);
+    assert_eq!(trained.decompressor().decompress(&compressed), massive);
+}
+
+#[test]
+fn fsst12_empty_table_round_trip() {
+    let compressor = CompressorBuilder12::new().build();
+    let input: Vec<u8> = (0..=255u8).cycle().take(4096).collect();
+    let compressed = compressor.compress(&input);
+    // Every byte → 1 code → 12 bits; 4096 codes pack into 6144 bytes.
+    assert_eq!(compressed.len(), input.len() * 3 / 2);
+    assert_eq!(compressor.decompressor().decompress(&compressed), input);
 }

--- a/tests/exact_capacity.rs
+++ b/tests/exact_capacity.rs
@@ -2,6 +2,7 @@
 
 #![cfg(test)]
 
+use fsst::fsst12::CompressorBuilder12;
 use fsst::{CompressorBuilder, Symbol};
 
 #[test]
@@ -32,6 +33,29 @@ fn test_decompress_exact_capacity() {
     let spare = decompressed.spare_capacity_mut();
 
     // This previously panicked with `exhaust input before output`. It should now succeed.
+    let len = decompressor.decompress_into(&compressed, spare);
+    unsafe { decompressed.set_len(len) };
+
+    assert_eq!(decompressed, plaintext);
+}
+
+#[test]
+fn fsst12_test_decompress_exact_capacity() {
+    // SWAR writes 8 bytes per code; with exactly `plaintext.len()` capacity, the safe
+    // byte-by-byte tail must take over to avoid over-writing past the buffer end.
+    let compressor = {
+        let mut builder = CompressorBuilder12::new();
+        builder.insert(Symbol::from_slice(b"aaaaaaaa"), 8);
+        builder.build()
+    };
+
+    let plaintext = vec![b'a'; 100_000];
+    let compressed = compressor.compress(&plaintext);
+
+    let decompressor = compressor.decompressor();
+
+    let mut decompressed = Vec::with_capacity(plaintext.len());
+    let spare = decompressed.spare_capacity_mut();
     let len = decompressor.decompress_into(&compressed, spare);
     unsafe { decompressed.set_len(len) };
 


### PR DESCRIPTION
Adds the FSST12 codec as a sibling module to the classic 8-bit codec, matching the variant defined in the [cwida/fsst](https://github.com/cwida/fsst) reference implementation: 12-bit codes (4096 entries), first 256 reserved as single-byte identity codes, no escape mechanism, output bit-packed at 1.5 bytes per code. Closes #142. Public surface is `fsst::fsst12::{Compressor12, CompressorBuilder12, Decompressor12}` mirroring the classic API; the classic 8-bit codec is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)