### PR TITLE
Decompress into uninit slice instead of vec

### DIFF
--- a/benches/compress.rs
+++ b/benches/compress.rs
@@ -74,7 +74,8 @@ fn run_bench(name: &str, buf: &[u8], c: &mut Criterion) {
     });
 
     unsafe {
-        compressor.compress_into(buf, buffer.spare_capacity_mut());
+        let length = compressor.compress_into(buf, buffer.spare_capacity_mut());
+        buffer.set_len(length);
     };
     let decompressor = compressor.decompressor();
     group.bench_function("decompress", |b| {

--- a/benches/compress.rs
+++ b/benches/compress.rs
@@ -70,11 +70,11 @@ fn run_bench(name: &str, buf: &[u8], c: &mut Criterion) {
     let mut buffer = Vec::with_capacity(buf.len() * 2);
     group.throughput(Throughput::Bytes(buf.len() as u64));
     group.bench_function("compress-only", |b| {
-        b.iter(|| unsafe { compressor.compress_into(buf, &mut buffer) });
+        b.iter(|| unsafe { compressor.compress_into(buf, buffer.spare_capacity_mut()) });
     });
 
     unsafe {
-        compressor.compress_into(buf, &mut buffer);
+        compressor.compress_into(buf, buffer.spare_capacity_mut());
     };
     let decompressor = compressor.decompressor();
     group.bench_function("decompress", |b| {

--- a/benches/micro.rs
+++ b/benches/micro.rs
@@ -203,7 +203,7 @@ fn bench_compress(c: &mut Criterion) {
         let compressor = compressor.build();
 
         b.iter(|| unsafe {
-            compressor.compress_into(&test_string, &mut output_buf);
+            compressor.compress_into(&test_string, output_buf.spare_capacity_mut());
         })
     });
     group.finish();
@@ -220,7 +220,7 @@ fn bench_compress(c: &mut Criterion) {
         let compressor = compressor.build();
 
         b.iter(|| unsafe {
-            compressor.compress_into(&test_string, &mut output_buf);
+            compressor.compress_into(&test_string, output_buf.spare_capacity_mut());
         })
     });
     group.finish();
@@ -234,7 +234,7 @@ fn bench_compress(c: &mut Criterion) {
         let compressor = compressor.build();
 
         b.iter(|| unsafe {
-            compressor.compress_into(&test_string, &mut output_buf);
+            compressor.compress_into(&test_string, output_buf.spare_capacity_mut());
         })
     });
     group.finish();
@@ -248,7 +248,7 @@ fn bench_compress(c: &mut Criterion) {
         let compressor = compressor.build();
 
         b.iter(|| unsafe {
-            compressor.compress_into(&test_string, &mut output_buf);
+            compressor.compress_into(&test_string, output_buf.spare_capacity_mut());
         })
     });
 
@@ -271,7 +271,7 @@ fn bench_compress(c: &mut Criterion) {
     let escape_compressor = CompressorBuilder::new().build();
     group.bench_function("compress", |b| {
         b.iter(|| unsafe {
-            escape_compressor.compress_into(&test_string, &mut output_buf);
+            escape_compressor.compress_into(&test_string, output_buf.spare_capacity_mut());
         })
     });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -661,13 +661,12 @@ impl Compressor {
         res
     }
 
-    /// Compress a string, writing its result into a target buffer.
+    /// Compress a string, writing its result into the target slice.
     ///
-    /// The target buffer is a byte vector that must have capacity large enough
-    /// to hold the encoded data.
+    /// The target buffer must have enough capacity to hold the encoded data.
     ///
-    /// When this call returns, `values` will hold the compressed bytes and have
-    /// its length set to the length of the compressed text.
+    /// When this call returns, `values` will hold the compressed bytes up to
+    /// return value.
     ///
     /// ```
     /// use fsst::{Compressor, CompressorBuilder, Symbol};
@@ -681,8 +680,9 @@ impl Compressor {
     ///
     /// // SAFETY: we have over-sized compressed_values.
     /// unsafe {
-    ///     compressor.compress_into(b"aaaaaaaa", &mut compressed_values);
-    /// }
+    ///     let valid_length = compressor.compress_into(b"aaaaaaaa", &mut compressed_values);
+    ///     compressed_values.set_len(valid_length);
+    /// };
     ///
     /// assert_eq!(compressed_values, vec![0u8]);
     /// ```
@@ -691,21 +691,20 @@ impl Compressor {
     ///
     /// It is up to the caller to ensure the provided buffer is large enough to hold
     /// all encoded data.
-    pub unsafe fn compress_into(&self, plaintext: &[u8], values: &mut Vec<u8>) {
+    pub unsafe fn compress_into(&self, plaintext: &[u8], values: &mut [MaybeUninit<u8>]) -> usize {
         // input is empty, we must set the output length's to 0.
         if plaintext.is_empty() {
-            values.clear();
-            return;
+            return 0;
         }
 
         let mut in_ptr = plaintext.as_ptr();
-        let mut out_ptr = values.as_mut_ptr();
+        let mut out_ptr = values.as_mut_ptr().cast::<u8>();
 
         // SAFETY: `end` will point just after the end of the `plaintext` slice.
         let in_end = unsafe { in_ptr.byte_add(plaintext.len()) };
         let in_end_sub8 = in_end as usize - 8;
         // SAFETY: `end` will point just after the end of the `values` allocation.
-        let out_end = unsafe { out_ptr.byte_add(values.capacity()) };
+        let out_end = unsafe { out_ptr.byte_add(values.len()) };
 
         while (in_ptr as usize) <= in_end_sub8 && unsafe { out_end.offset_from(out_ptr) } >= 2 {
             // SAFETY: pointer ranges are checked in the loop condition
@@ -771,14 +770,14 @@ impl Compressor {
         assert!(out_ptr <= out_end, "output buffer sized too small");
 
         // SAFETY: out_ptr is derived from the `values` allocation.
-        let bytes_written = unsafe { out_ptr.offset_from(values.as_ptr()) };
+        let bytes_written = unsafe { out_ptr.offset_from(values.as_ptr().cast()) };
         assert!(
             bytes_written >= 0,
             "out_ptr ended before it started, not possible"
         );
 
         // SAFETY: we have initialized `bytes_written` values in the output buffer.
-        unsafe { values.set_len(bytes_written as usize) };
+        bytes_written as usize
     }
 
     /// Use the symbol table to compress the plaintext into a sequence of codes and escapes.
@@ -790,7 +789,10 @@ impl Compressor {
         let mut buffer = Vec::with_capacity(plaintext.len() * 2);
 
         // SAFETY: the largest compressed size would be all escapes == 2*plaintext_len
-        unsafe { self.compress_into(plaintext, &mut buffer) };
+        unsafe {
+            let length = self.compress_into(plaintext, buffer.spare_capacity_mut());
+            buffer.set_len(length);
+        };
 
         buffer
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -680,7 +680,7 @@ impl Compressor {
     ///
     /// // SAFETY: we have over-sized compressed_values.
     /// unsafe {
-    ///     let valid_length = compressor.compress_into(b"aaaaaaaa", &mut compressed_values);
+    ///     let valid_length = compressor.compress_into(b"aaaaaaaa", compressed_values.spare_capacity_mut());
     ///     compressed_values.set_len(valid_length);
     /// };
     ///

--- a/tests/exact_capacity.rs
+++ b/tests/exact_capacity.rs
@@ -106,7 +106,8 @@ fn test_decompress_exact_capacity() {
     // Compress it into an over-allocated buffer to avoid any compression bugs
     let mut compressed = Vec::with_capacity(plaintext.len() * 2);
     unsafe {
-        compressor.compress_into(&plaintext, &mut compressed);
+        let length = compressor.compress_into(&plaintext, compressed.spare_capacity_mut());
+        compressed.set_len(length);
     }
 
     let decompressor = compressor.decompressor();
@@ -150,12 +151,14 @@ fn decompress_mixed_stream_matches_model(tc: hegel::TestCase) {
 #[hegel::test]
 fn compress_into_empty_clears_output(tc: hegel::TestCase) {
     let compressor = CompressorBuilder::new().build();
-    let mut output = tc.draw(generators::binary());
+    let length = tc.draw(generators::integers().max_value(i32::MAX as usize));
+
+    let mut output = Vec::with_capacity(length);
 
     // SAFETY: empty input requires no output capacity.
-    unsafe { compressor.compress_into(&[], &mut output) };
+    let length = unsafe { compressor.compress_into(&[], output.spare_capacity_mut()) };
 
-    assert!(output.is_empty());
+    assert_eq!(length, 0);
 }
 
 #[cfg_attr(miri, ignore)]
@@ -186,7 +189,10 @@ fn compress_into_exact_capacity_matches_compress(tc: hegel::TestCase) {
     let expected = compressor.compress(&plaintext);
     let mut exact = Vec::with_capacity(expected.len());
     // SAFETY: exact has the capacity required by the canonical compression result.
-    unsafe { compressor.compress_into(&plaintext, &mut exact) };
+    unsafe {
+        let length = compressor.compress_into(&plaintext, exact.spare_capacity_mut());
+        exact.set_len(length);
+    };
 
     assert_eq!(exact, expected);
 }


### PR DESCRIPTION
This makes the API more flexible, allowing other Vec-like types (Like the popular `bytes::BytesMut) to work here