### PR TITLE
Peek ahead in compression probe

### DIFF
--- a/benches/compress.rs
+++ b/benches/compress.rs
@@ -73,6 +73,23 @@ fn run_bench(name: &str, buf: &[u8], c: &mut Criterion) {
         b.iter(|| unsafe { compressor.compress_into(buf, buffer.spare_capacity_mut()) });
     });
 
+    // Row-wise bulk compression: values are compressed independently of one another, which is
+    // what lets `compress_bulk_into` run several cursors at once.
+    let lines: Vec<&[u8]> = buf.split(|&b| b == b'\n').collect();
+    let mut bulk_output: Vec<u8> = Vec::with_capacity(buf.len() * 2);
+    let mut bulk_offsets: Vec<u64> = Vec::with_capacity(lines.len());
+    group.bench_function("compress-bulk-into", |b| {
+        b.iter(|| {
+            bulk_output.clear();
+            bulk_offsets.clear();
+            compressor.compress_bulk_into(&lines, &mut bulk_output, &mut bulk_offsets);
+        });
+    });
+
+    group.bench_function("compress-bulk", |b| {
+        b.iter_with_large_drop(|| compressor.compress_bulk(std::hint::black_box(&lines)));
+    });
+
     unsafe {
         let length = compressor.compress_into(buf, buffer.spare_capacity_mut());
         buffer.set_len(length);

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -8,7 +8,7 @@
 use std::mem::MaybeUninit;
 use std::ptr;
 
-use crate::Compressor;
+use crate::{Compressor, advance_8byte_word};
 
 /// Number of independent cursors [`Compressor::compress_bulk_into`] interleaves.
 ///
@@ -139,10 +139,15 @@ impl Compressor {
         }
         lane_out_base[K] = cursor;
 
-        // End offset of every value, relative to `spare_ptr`, before the lanes are compacted.
-        let mut ends = vec![0u64; values.len()];
+        // Write the temporary, pre-compaction ends directly into the offsets allocation. Every
+        // value gets exactly one end before the length is exposed, so this avoids allocating and
+        // zeroing a second values-sized array only to copy it into `offsets` afterward.
+        let offsets_base = offsets.len();
+        // SAFETY: `offsets` reserved room for every value above. Nothing touches its allocation
+        // again until all ends are written and the length is updated.
+        let ends_ptr = unsafe { offsets.as_mut_ptr().add(offsets_base) };
 
-        let mut lanes: [Lane; MAX_LANES] = std::array::from_fn(|_| Lane {
+        let mut lanes: [Lane; K] = std::array::from_fn(|_| Lane {
             in_ptr: ptr::null(),
             in_end: ptr::null(),
             out_ptr: ptr::null_mut(),
@@ -170,7 +175,7 @@ impl Compressor {
             for lane in 0..K {
                 while (lanes[lane].in_ptr as usize) + 8 > lanes[lane].in_end as usize {
                     // SAFETY: the lane's pointers are within its own value and output slice.
-                    unsafe { self.finish_value(&mut lanes[lane], values, spare_ptr, &mut ends) };
+                    unsafe { self.finish_value(&mut lanes[lane], values, spare_ptr, ends_ptr) };
                     lanes[lane].value += 1;
                     if lanes[lane].value == lanes[lane].value_end {
                         break 'interleaved;
@@ -184,12 +189,16 @@ impl Compressor {
 
             // One step of every cursor. These are independent, so their symbol-table lookups
             // overlap instead of serializing.
-            for lane in &mut lanes[..K] {
+            for lane in &mut lanes {
                 // SAFETY: the check above leaves at least 8 readable bytes in the current value,
                 // and the lane's output slice has room for two bytes per input byte consumed.
                 unsafe {
                     let word = ptr::read_unaligned(lane.in_ptr as *const u64);
-                    let (advance_in, advance_out) = self.compress_word(word, lane.out_ptr);
+                    let (advance_in, advance_out) = if K == 1 {
+                        self.compress_word(word, lane.out_ptr)
+                    } else {
+                        self.compress_word_branchless(word, lane.out_ptr)
+                    };
                     lane.in_ptr = lane.in_ptr.add(advance_in);
                     lane.out_ptr = lane.out_ptr.add(advance_out);
                 }
@@ -200,7 +209,7 @@ impl Compressor {
         for lane in 0..K {
             while lanes[lane].value < lanes[lane].value_end {
                 // SAFETY: as above.
-                unsafe { self.finish_value(&mut lanes[lane], values, spare_ptr, &mut ends) };
+                unsafe { self.finish_value(&mut lanes[lane], values, spare_ptr, ends_ptr) };
                 lanes[lane].value += 1;
                 if lanes[lane].value < lanes[lane].value_end {
                     let bytes = values[lanes[lane].value];
@@ -210,6 +219,12 @@ impl Compressor {
                 }
             }
         }
+
+        // Every value's end has now been initialized.
+        // SAFETY: each of the K non-empty lane ranges covers a disjoint part of `values`, and the
+        // loops above finish every value in every range exactly once.
+        unsafe { offsets.set_len(offsets_base + values.len()) };
+        let ends = &mut offsets[offsets_base..];
 
         // The lanes wrote into disjoint slices sized for the worst case, so the compressed bytes
         // are separated by gaps. Slide each lane down onto the end of the previous one, and shift
@@ -229,8 +244,8 @@ impl Compressor {
                 unsafe { ptr::copy(spare_ptr.add(lane_start), spare_ptr.add(written), lane_len) };
             }
             let shift = (lane_start - written) as u64;
-            for end in &ends[bounds[lane]..bounds[lane + 1]] {
-                offsets.push(end - shift + base as u64);
+            for end in &mut ends[bounds[lane]..bounds[lane + 1]] {
+                *end = *end - shift + base as u64;
             }
             written += lane_len;
         }
@@ -249,7 +264,7 @@ impl Compressor {
         lane: &mut Lane,
         values: &[&[u8]],
         spare_ptr: *mut u8,
-        ends: &mut [u64],
+        ends_ptr: *mut u64,
     ) {
         let bytes = values[lane.value];
         // SAFETY: `in_ptr` is within the value, by the caller's contract.
@@ -265,14 +280,56 @@ impl Compressor {
             let out = unsafe {
                 std::slice::from_raw_parts_mut(lane.out_ptr.cast::<MaybeUninit<u8>>(), capacity)
             };
-            // SAFETY: `out` is large enough for the worst case, as argued above.
-            let written = unsafe { self.compress_into(rest, out) };
+            // The interleaved loop normally leaves fewer than eight bytes. Avoid sending that
+            // common case through the general compression loop, whose output-bound checks and
+            // one-byte-capacity fallback are unnecessary with the worst-case-sized lane slice.
+            let written = if rest.len() < 8 {
+                // SAFETY: `out` has room for two bytes per input byte.
+                unsafe { self.compress_tail(rest, out.as_mut_ptr().cast()) }
+            } else {
+                // SAFETY: `out` is large enough for the worst case, as argued above.
+                unsafe { self.compress_into(rest, out) }
+            };
             // SAFETY: `written` bytes were just written into the lane's slice.
             lane.out_ptr = unsafe { lane.out_ptr.add(written) };
         }
 
         // SAFETY: `out_ptr` is derived from `spare_ptr`.
-        ends[lane.value] = unsafe { lane.out_ptr.offset_from(spare_ptr) } as u64;
+        // SAFETY: the caller reserved one offset per input value, and each lane's value index is
+        // within that range and disjoint from every other lane's range.
+        unsafe {
+            ends_ptr
+                .add(lane.value)
+                .write(lane.out_ptr.offset_from(spare_ptr) as u64)
+        };
+    }
+
+    /// Compress a non-empty tail shorter than a word into worst-case-sized output storage.
+    ///
+    /// # Safety
+    ///
+    /// `out_ptr` must have room for two bytes per input byte.
+    unsafe fn compress_tail(&self, input: &[u8], out_ptr: *mut u8) -> usize {
+        debug_assert!(!input.is_empty() && input.len() < 8);
+
+        let mut bytes = [0u8; 8];
+        // SAFETY: the source contains `input.len()` bytes, and the eight-byte destination does too.
+        unsafe { ptr::copy_nonoverlapping(input.as_ptr(), bytes.as_mut_ptr(), input.len()) };
+        let mut word = u64::from_le_bytes(bytes);
+        let mut consumed = 0usize;
+        let mut written = 0usize;
+
+        while consumed < input.len() {
+            // SAFETY: the caller provided worst-case-sized output. At least one input byte remains,
+            // so at least two writable output bytes remain for the speculative escape write.
+            let (advance_in, advance_out) =
+                unsafe { self.compress_word(word, out_ptr.add(written)) };
+            consumed += advance_in;
+            written += advance_out;
+            word = advance_8byte_word(word, advance_in);
+        }
+
+        written
     }
 
     /// Compress every value one after another, with no interleaving.

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -1,0 +1,310 @@
+//! Bulk compression that interleaves several independent cursors.
+//!
+//! A single compression cursor is latency-bound: the number of bytes each iteration consumes
+//! comes out of that iteration's symbol-table lookup, so the next lookup cannot start until the
+//! previous one lands. Values are compressed independently of one another, so running several
+//! cursors over disjoint ranges of values keeps several of those chains in flight at once.
+
+use std::mem::MaybeUninit;
+use std::ptr;
+
+use crate::Compressor;
+
+/// Number of independent cursors [`Compressor::compress_bulk_into`] interleaves.
+///
+/// Throughput climbs steeply from one to four cursors and then falls back as the working set of
+/// each iteration outgrows the register file.
+const LANES: usize = 4;
+
+/// Largest lane count the fixed-size per-lane arrays below can hold.
+///
+/// Throughput already falls off well before this, so the ceiling only has to be high enough to
+/// measure the falloff.
+const MAX_LANES: usize = 16;
+
+/// State of a single cursor.
+struct Lane {
+    /// Next input byte to consume.
+    in_ptr: *const u8,
+    /// End of the value currently being compressed.
+    in_end: *const u8,
+    /// Next output byte to write.
+    out_ptr: *mut u8,
+    /// Index of the value currently being compressed.
+    value: usize,
+    /// One past the last value index owned by this lane.
+    value_end: usize,
+}
+
+impl Compressor {
+    /// Compress many values into a single contiguous buffer.
+    ///
+    /// The compressed bytes of every value are appended to `output`, and the end offset of every
+    /// value is appended to `offsets`. Offsets are absolute indices into `output`, so with `k`
+    /// the length of `offsets` before the call and `start` the length of `output` before the
+    /// call, `values[i]` occupies `output[s..offsets[k + i]]`, where `s` is `start` for `i == 0`
+    /// and `offsets[k + i - 1]` otherwise.
+    ///
+    /// Each value is compressed independently, exactly as [`Self::compress`] would compress it,
+    /// so any one of them can be decompressed on its own from that range.
+    ///
+    /// ```
+    /// use fsst::{Compressor, CompressorBuilder, Symbol};
+    ///
+    /// let compressor = {
+    ///     let mut builder = CompressorBuilder::new();
+    ///     builder.insert(Symbol::from_slice(&[b'h', b'e', b'l', b'l', b'o', 0, 0, 0]), 5);
+    ///     builder.build()
+    /// };
+    ///
+    /// let values: &[&[u8]] = &[b"hello", b"hellohello"];
+    /// let mut output = Vec::new();
+    /// let mut offsets = Vec::new();
+    /// compressor.compress_bulk_into(values, &mut output, &mut offsets);
+    ///
+    /// // "hello" is a single code, so the first value is one byte and the second is two.
+    /// assert_eq!(offsets, vec![1, 3]);
+    ///
+    /// let decompressor = compressor.decompressor();
+    /// assert_eq!(decompressor.decompress(&output[..1]), b"hello");
+    /// assert_eq!(decompressor.decompress(&output[1..3]), b"hellohello");
+    /// ```
+    pub fn compress_bulk_into(
+        &self,
+        values: &[&[u8]],
+        output: &mut Vec<u8>,
+        offsets: &mut Vec<u64>,
+    ) {
+        self.compress_bulk_lanes::<LANES>(values, output, offsets)
+    }
+
+    /// [`Self::compress_bulk_into`] with the cursor count exposed, so the best value for a given
+    /// machine can be measured rather than assumed.
+    ///
+    /// # Panics
+    ///
+    /// Panics unless `K` is in `1..=16`.
+    #[doc(hidden)]
+    pub fn compress_bulk_lanes<const K: usize>(
+        &self,
+        values: &[&[u8]],
+        output: &mut Vec<u8>,
+        offsets: &mut Vec<u64>,
+    ) {
+        assert!(
+            K > 0 && K <= MAX_LANES,
+            "lane count must be in 1..={MAX_LANES}"
+        );
+        if values.is_empty() {
+            return;
+        }
+
+        let total_in: usize = values.iter().map(|value| value.len()).sum();
+        let base = output.len();
+        offsets.reserve(values.len());
+
+        // Every value compresses to at most two bytes per input byte, so this is enough room for
+        // all of them, and enough for each lane to be given a disjoint slice of it up front.
+        output.reserve(2 * total_in);
+        let spare = output.spare_capacity_mut();
+        let spare_ptr: *mut u8 = spare.as_mut_ptr().cast();
+
+        if values.len() < K {
+            // SAFETY: `output` was just reserved to two bytes per byte of input.
+            let written = unsafe { self.compress_bulk_serial(values, spare_ptr, base, offsets) };
+            // SAFETY: bytes `base..base + written` of the allocation were initialized above.
+            unsafe { output.set_len(base + written) };
+            return;
+        }
+
+        // Split the values into K contiguous ranges. Splitting by index rather than by byte
+        // count keeps every lane non-empty, and values within one array are usually of similar
+        // length, so the ranges come out close to balanced anyway.
+        let mut bounds = [0usize; MAX_LANES + 1];
+        for (lane, bound) in bounds.iter_mut().enumerate().take(K + 1) {
+            *bound = lane * values.len() / K;
+        }
+
+        // Give each lane a disjoint slice of the output, sized to the worst case for its own
+        // values, so lanes never contend and no bounds check is needed in the interleaved loop.
+        let mut lane_out_base = [0usize; MAX_LANES + 1];
+        let mut cursor = 0usize;
+        for lane in 0..K {
+            lane_out_base[lane] = cursor;
+            let bytes: usize = values[bounds[lane]..bounds[lane + 1]]
+                .iter()
+                .map(|value| value.len())
+                .sum();
+            cursor += 2 * bytes;
+        }
+        lane_out_base[K] = cursor;
+
+        // End offset of every value, relative to `spare_ptr`, before the lanes are compacted.
+        let mut ends = vec![0u64; values.len()];
+
+        let mut lanes: [Lane; MAX_LANES] = std::array::from_fn(|_| Lane {
+            in_ptr: ptr::null(),
+            in_end: ptr::null(),
+            out_ptr: ptr::null_mut(),
+            value: 0,
+            value_end: 0,
+        });
+        for lane in 0..K {
+            let value = bounds[lane];
+            let bytes = values[value];
+            lanes[lane] = Lane {
+                in_ptr: bytes.as_ptr(),
+                // SAFETY: one past the end of the value's own allocation.
+                in_end: unsafe { bytes.as_ptr().add(bytes.len()) },
+                // SAFETY: `lane_out_base[lane]` is within the reserved spare capacity.
+                out_ptr: unsafe { spare_ptr.add(lane_out_base[lane]) },
+                value,
+                value_end: bounds[lane + 1],
+            };
+        }
+
+        'interleaved: loop {
+            // Bring every lane up to at least a full word of input, finishing values and moving
+            // on to the next one as needed. This is the only branch in the loop that depends on
+            // the data, and it is taken about once per value rather than once per iteration.
+            for lane in 0..K {
+                while (lanes[lane].in_ptr as usize) + 8 > lanes[lane].in_end as usize {
+                    // SAFETY: the lane's pointers are within its own value and output slice.
+                    unsafe { self.finish_value(&mut lanes[lane], values, spare_ptr, &mut ends) };
+                    lanes[lane].value += 1;
+                    if lanes[lane].value == lanes[lane].value_end {
+                        break 'interleaved;
+                    }
+                    let bytes = values[lanes[lane].value];
+                    lanes[lane].in_ptr = bytes.as_ptr();
+                    // SAFETY: one past the end of the value's own allocation.
+                    lanes[lane].in_end = unsafe { bytes.as_ptr().add(bytes.len()) };
+                }
+            }
+
+            // One step of every cursor. These are independent, so their symbol-table lookups
+            // overlap instead of serializing.
+            for lane in &mut lanes[..K] {
+                // SAFETY: the check above leaves at least 8 readable bytes in the current value,
+                // and the lane's output slice has room for two bytes per input byte consumed.
+                unsafe {
+                    let word = ptr::read_unaligned(lane.in_ptr as *const u64);
+                    let (advance_in, advance_out) = self.compress_word(word, lane.out_ptr);
+                    lane.in_ptr = lane.in_ptr.add(advance_in);
+                    lane.out_ptr = lane.out_ptr.add(advance_out);
+                }
+            }
+        }
+
+        // Drain whatever is left in each lane once the first one has run out of values.
+        for lane in 0..K {
+            while lanes[lane].value < lanes[lane].value_end {
+                // SAFETY: as above.
+                unsafe { self.finish_value(&mut lanes[lane], values, spare_ptr, &mut ends) };
+                lanes[lane].value += 1;
+                if lanes[lane].value < lanes[lane].value_end {
+                    let bytes = values[lanes[lane].value];
+                    lanes[lane].in_ptr = bytes.as_ptr();
+                    // SAFETY: one past the end of the value's own allocation.
+                    lanes[lane].in_end = unsafe { bytes.as_ptr().add(bytes.len()) };
+                }
+            }
+        }
+
+        // The lanes wrote into disjoint slices sized for the worst case, so the compressed bytes
+        // are separated by gaps. Slide each lane down onto the end of the previous one, and shift
+        // its offsets by the same amount.
+        let mut written = 0usize;
+        for lane in 0..K {
+            let lane_start = lane_out_base[lane];
+            let lane_len = if bounds[lane] == bounds[lane + 1] {
+                0
+            } else {
+                ends[bounds[lane + 1] - 1] as usize - lane_start
+            };
+            if lane_start != written {
+                // SAFETY: both ranges are inside the reserved spare capacity, and the
+                // destination starts at or before the source, so the copy is well-formed even
+                // when the ranges overlap.
+                unsafe { ptr::copy(spare_ptr.add(lane_start), spare_ptr.add(written), lane_len) };
+            }
+            let shift = (lane_start - written) as u64;
+            for end in &ends[bounds[lane]..bounds[lane + 1]] {
+                offsets.push(end - shift + base as u64);
+            }
+            written += lane_len;
+        }
+
+        // SAFETY: bytes `base..base + written` of the allocation were initialized above.
+        unsafe { output.set_len(base + written) };
+    }
+
+    /// Compress the unconsumed remainder of the lane's current value and record its end offset.
+    ///
+    /// # Safety
+    ///
+    /// The lane's pointers must lie within its current value and its own output slice.
+    unsafe fn finish_value(
+        &self,
+        lane: &mut Lane,
+        values: &[&[u8]],
+        spare_ptr: *mut u8,
+        ends: &mut [u64],
+    ) {
+        let bytes = values[lane.value];
+        // SAFETY: `in_ptr` is within the value, by the caller's contract.
+        let consumed = unsafe { lane.in_ptr.offset_from(bytes.as_ptr()) } as usize;
+        let rest = &bytes[consumed..];
+
+        if !rest.is_empty() {
+            // The lane's slice always holds two bytes per byte of input it has left, so a
+            // worst-case all-escape remainder still fits.
+            let capacity = 2 * rest.len();
+            // SAFETY: `out_ptr` is inside the lane's slice, which has at least `capacity` bytes
+            // left, and uninitialized `u8` is a valid `MaybeUninit<u8>`.
+            let out = unsafe {
+                std::slice::from_raw_parts_mut(lane.out_ptr.cast::<MaybeUninit<u8>>(), capacity)
+            };
+            // SAFETY: `out` is large enough for the worst case, as argued above.
+            let written = unsafe { self.compress_into(rest, out) };
+            // SAFETY: `written` bytes were just written into the lane's slice.
+            lane.out_ptr = unsafe { lane.out_ptr.add(written) };
+        }
+
+        // SAFETY: `out_ptr` is derived from `spare_ptr`.
+        ends[lane.value] = unsafe { lane.out_ptr.offset_from(spare_ptr) } as u64;
+    }
+
+    /// Compress every value one after another, with no interleaving.
+    ///
+    /// Used when there are too few values to give every cursor one.
+    ///
+    /// # Safety
+    ///
+    /// `spare_ptr` must have room for two bytes per byte of input.
+    unsafe fn compress_bulk_serial(
+        &self,
+        values: &[&[u8]],
+        spare_ptr: *mut u8,
+        base: usize,
+        offsets: &mut Vec<u64>,
+    ) -> usize {
+        let mut written = 0usize;
+        for value in values.iter() {
+            if !value.is_empty() {
+                let capacity = 2 * value.len();
+                // SAFETY: the caller reserved two bytes per input byte for every value.
+                let out = unsafe {
+                    std::slice::from_raw_parts_mut(
+                        spare_ptr.add(written).cast::<MaybeUninit<u8>>(),
+                        capacity,
+                    )
+                };
+                // SAFETY: `out` is large enough for the worst case.
+                written += unsafe { self.compress_into(value, out) };
+            }
+            offsets.push((base + written) as u64);
+        }
+        written
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -622,12 +622,73 @@ impl Compressor {
         // SAFETY: codes_two_byte has exactly 65536 entries and `word as u16` is always in [0, 65535].
         let code_twobyte = unsafe { *self.codes_two_byte.get_unchecked(word as u16 as usize) };
 
-        // Peek ahead: probe the hash table unconditionally, so its load issues alongside the
-        // two-byte load rather than behind a data-dependent branch.
-        //
-        // The two probes are independent, so the out-of-order engine overlaps their latency, and
-        // the loop body becomes straight-line code that ends in a select. That trades a probe we
-        // may not need for the mispredicts of a branch that is close to a coin flip on mixed text.
+        if code_twobyte.code() < self.has_suffix_code {
+            // 2 byte code without having to worry about longer matches.
+            // SAFETY: out_ptr is not null.
+            unsafe { std::ptr::write(out_ptr, code_twobyte.code()) };
+
+            // Advance input by symbol length (2) and output by a single code byte
+            (2, 1)
+        } else {
+            // Probe the hash table
+            let entry = self.lossy_pht.lookup(word);
+
+            // Now, downshift the `word` and the `entry` to see if they align.
+            let ignored_bits = entry.ignored_bits;
+            if entry.code != Code::UNUSED
+                && compare_masked(word, entry.symbol.to_u64(), ignored_bits)
+            {
+                // Advance the input by the symbol length (variable) and the output by one code byte
+                // SAFETY: out_ptr is not null.
+                unsafe { std::ptr::write(out_ptr, entry.code.code()) };
+                (entry.code.len() as usize, 1)
+            } else {
+                // SAFETY: out_ptr is not null
+                unsafe { std::ptr::write(out_ptr, code_twobyte.code()) };
+
+                // Advance the input by the symbol length (variable) and the output by either 1
+                // byte (if was one-byte code) or two bytes (escape).
+                (
+                    code_twobyte.len() as usize,
+                    // Predicated version of:
+                    //
+                    // if entry.code >= 256 {
+                    //      2
+                    // } else {
+                    //      1
+                    // }
+                    1 + (code_twobyte.extended_code() >> 8) as usize,
+                )
+            }
+        }
+    }
+
+    /// Branchless variant of [`Self::compress_word`] used when several independent cursors are
+    /// interleaved.
+    ///
+    /// Probing both lookup tables unconditionally avoids a branch misprediction flushing every
+    /// cursor currently in flight. A single cursor uses [`Self::compress_word`] instead, because
+    /// avoiding the unnecessary hash probe is faster on predictable inputs.
+    ///
+    /// # Safety
+    ///
+    /// `out_ptr` must never be NULL or otherwise point to invalid memory.
+    pub(crate) unsafe fn compress_word_branchless(
+        &self,
+        word: u64,
+        out_ptr: *mut u8,
+    ) -> (usize, usize) {
+        // Speculatively write the first byte of `word` at offset 1. This is necessary if it is an
+        // escape, and if it isn't, it will be overwritten anyway.
+        let first_byte = word as u8;
+        // SAFETY: out_ptr is not null.
+        unsafe { out_ptr.byte_add(1).write_unaligned(first_byte) };
+
+        // SAFETY: codes_two_byte has exactly 65536 entries and `word as u16` is always in
+        // [0, 65535].
+        let code_twobyte = unsafe { *self.codes_two_byte.get_unchecked(word as u16 as usize) };
+
+        // Issue the independent hash-table probe alongside the two-byte table load.
         let entry = self.lossy_pht.lookup(word);
 
         // `&` rather than `&&`: short-circuiting would reintroduce the branches this is removing.
@@ -636,22 +697,11 @@ impl Compressor {
             & compare_masked_lenient(word, entry.symbol.to_u64(), entry.ignored_bits);
 
         let (code, advance_in, advance_out) = if use_pht {
-            // Advance the input by the symbol length (variable) and the output by one code byte.
             (entry.code.code(), entry.code.len() as usize, 1)
         } else {
-            // Either a two-byte code that cannot have a longer match, or a one-byte code or
-            // escape. Advance the input by the symbol length and the output by either 1 byte
-            // (one-byte code) or 2 bytes (escape).
             (
                 code_twobyte.code(),
                 code_twobyte.len() as usize,
-                // Predicated version of:
-                //
-                // if code_twobyte.extended_code() >= 256 {
-                //      2
-                // } else {
-                //      1
-                // }
                 1 + (code_twobyte.extended_code() >> 8) as usize,
             )
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -621,45 +621,43 @@ impl Compressor {
         // SAFETY: codes_two_byte has exactly 65536 entries and `word as u16` is always in [0, 65535].
         let code_twobyte = unsafe { *self.codes_two_byte.get_unchecked(word as u16 as usize) };
 
-        if code_twobyte.code() < self.has_suffix_code {
-            // 2 byte code without having to worry about longer matches.
-            // SAFETY: out_ptr is not null.
-            unsafe { std::ptr::write(out_ptr, code_twobyte.code()) };
+        // Peek ahead: probe the hash table unconditionally, so its load issues alongside the
+        // two-byte load rather than behind a data-dependent branch.
+        //
+        // The two probes are independent, so the out-of-order engine overlaps their latency, and
+        // the loop body becomes straight-line code that ends in a select. That trades a probe we
+        // may not need for the mispredicts of a branch that is close to a coin flip on mixed text.
+        let entry = self.lossy_pht.lookup(word);
 
-            // Advance input by symbol length (2) and output by a single code byte
-            (2, 1)
+        // `&` rather than `&&`: short-circuiting would reintroduce the branches this is removing.
+        let use_pht = (code_twobyte.code() >= self.has_suffix_code)
+            & (entry.code != Code::UNUSED)
+            & compare_masked_lenient(word, entry.symbol.to_u64(), entry.ignored_bits);
+
+        let (code, advance_in, advance_out) = if use_pht {
+            // Advance the input by the symbol length (variable) and the output by one code byte.
+            (entry.code.code(), entry.code.len() as usize, 1)
         } else {
-            // Probe the hash table
-            let entry = self.lossy_pht.lookup(word);
+            // Either a two-byte code that cannot have a longer match, or a one-byte code or
+            // escape. Advance the input by the symbol length and the output by either 1 byte
+            // (one-byte code) or 2 bytes (escape).
+            (
+                code_twobyte.code(),
+                code_twobyte.len() as usize,
+                // Predicated version of:
+                //
+                // if code_twobyte.extended_code() >= 256 {
+                //      2
+                // } else {
+                //      1
+                // }
+                1 + (code_twobyte.extended_code() >> 8) as usize,
+            )
+        };
 
-            // Now, downshift the `word` and the `entry` to see if they align.
-            let ignored_bits = entry.ignored_bits;
-            if entry.code != Code::UNUSED
-                && compare_masked(word, entry.symbol.to_u64(), ignored_bits)
-            {
-                // Advance the input by the symbol length (variable) and the output by one code byte
-                // SAFETY: out_ptr is not null.
-                unsafe { std::ptr::write(out_ptr, entry.code.code()) };
-                (entry.code.len() as usize, 1)
-            } else {
-                // SAFETY: out_ptr is not null
-                unsafe { std::ptr::write(out_ptr, code_twobyte.code()) };
-
-                // Advance the input by the symbol length (variable) and the output by either 1
-                // byte (if was one-byte code) or two bytes (escape).
-                (
-                    code_twobyte.len() as usize,
-                    // Predicated version of:
-                    //
-                    // if entry.code >= 256 {
-                    //      2
-                    // } else {
-                    //      1
-                    // }
-                    1 + (code_twobyte.extended_code() >> 8) as usize,
-                )
-            }
-        }
+        // SAFETY: out_ptr is not null.
+        unsafe { std::ptr::write(out_ptr, code) };
+        (advance_in, advance_out)
     }
 
     /// Compress many lines in bulk.
@@ -962,6 +960,18 @@ fn validate_symbol_order(symbol_lens: &[u8]) {
 #[inline]
 pub(crate) fn compare_masked(left: u64, right: u64, ignored_bits: u16) -> bool {
     let mask = u64::MAX >> ignored_bits;
+    (left & mask) == right
+}
+
+/// As [`compare_masked`], but also defined when `ignored_bits == 64`, which is the value stored
+/// in an unused hash slot.
+///
+/// The compression loop evaluates the comparison before it has established that the slot is in
+/// use, so the shift must not overflow. An unused slot is rejected by a separate check on the
+/// code, so the mask only has to be well-defined in that case, not meaningful.
+#[inline]
+pub(crate) fn compare_masked_lenient(left: u64, right: u64, ignored_bits: u16) -> bool {
+    let mask = u64::MAX.wrapping_shr(ignored_bits as u32);
     (left & mask) == right
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use std::fmt::{Debug, Formatter};
 use std::mem::MaybeUninit;
 
 mod builder;
+mod bulk;
 mod lossy_pht;
 
 pub use builder::*;

--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -230,3 +230,32 @@ fn test_pruning_small_input() {
     let compressed = compressor.compress(&corpus);
     assert_eq!(compressor.decompressor().decompress(&compressed), corpus);
 }
+
+/// The compression loop evaluates the masked symbol comparison before it has established that
+/// the hash slot is in use, so an unused slot (whose stored symbol is zero and whose
+/// `ignored_bits` is 64) must never be mistaken for a match. An all-zero word probing an unused
+/// slot is the case that catches it: with a full-width mask, `word & mask` would equal the
+/// slot's zero symbol.
+#[test]
+fn test_zero_word_does_not_match_unused_hash_slot() {
+    let mut builder = CompressorBuilder::new();
+    // A single three-byte symbol, so the hash table has exactly one slot in use.
+    assert!(builder.insert(Symbol::from_slice(b"xyz\0\0\0\0\0"), 3));
+    let compressor = builder.build();
+
+    for len in [1usize, 7, 8, 9, 16, 33, 64] {
+        let corpus = vec![0u8; len];
+        let compressed = compressor.compress(&corpus);
+        assert_eq!(
+            compressor.decompressor().decompress(&compressed),
+            corpus,
+            "all-zero input of length {len} did not round trip"
+        );
+        // Every byte is an escape: no symbol in the table matches a zero byte.
+        assert_eq!(
+            compressed.len(),
+            2 * len,
+            "length {len} should be all escapes"
+        );
+    }
+}

--- a/tests/correctness.rs
+++ b/tests/correctness.rs
@@ -259,3 +259,158 @@ fn test_zero_word_does_not_match_unused_hash_slot() {
         );
     }
 }
+
+/// `compress_bulk_into` must produce, for every value, exactly the bytes `compress` would
+/// produce for that value on its own, so any single value can be decompressed from its range.
+fn check_bulk(compressor: &Compressor, values: &[&[u8]], label: &str) {
+    let mut output = Vec::new();
+    let mut offsets = Vec::new();
+    compressor.compress_bulk_into(values, &mut output, &mut offsets);
+
+    assert_eq!(offsets.len(), values.len(), "{label}: one offset per value");
+    let mut start = 0usize;
+    for (i, value) in values.iter().enumerate() {
+        let end = offsets[i] as usize;
+        assert!(
+            start <= end && end <= output.len(),
+            "{label}: value {i} has a bogus range"
+        );
+        assert_eq!(
+            &output[start..end],
+            compressor.compress(value),
+            "{label}: value {i}"
+        );
+        assert_eq!(
+            compressor.decompressor().decompress(&output[start..end]),
+            *value,
+            "{label}: value {i} round trip"
+        );
+        start = end;
+    }
+    assert_eq!(start, output.len(), "{label}: output has trailing bytes");
+}
+
+#[test]
+fn test_compress_bulk_into_matches_compress() {
+    let lines: Vec<&[u8]> = DECLARATION.as_bytes().split(|&b| b == b'\n').collect();
+    let compressor = Compressor::train(&lines);
+    check_bulk(&compressor, &lines, "declaration");
+
+    // Fewer values than cursors, and counts either side of the cursor count, exercise the
+    // serial fallback and the drain that runs once the first cursor runs out of values.
+    for n in [0usize, 1, 2, 3, 4, 5, 6, 7, 8, 9, 17] {
+        check_bulk(
+            &compressor,
+            &lines[..n.min(lines.len())],
+            &format!("declaration[..{n}]"),
+        );
+    }
+}
+
+#[test]
+fn test_compress_bulk_into_ragged_values() {
+    let long = &ART_OF_WAR.as_bytes()[..scaled(ART_OF_WAR.len(), 512)];
+    let compressor = Compressor::train(&vec![long]);
+
+    // Values shorter than a word never enter the interleaved loop at all, and empty values must
+    // still get an offset.
+    let values: Vec<&[u8]> = vec![
+        b"",
+        b"a",
+        b"",
+        b"abcdefg",
+        b"abcdefgh",
+        b"abcdefghi",
+        long,
+        b"",
+        b"zz",
+    ];
+    check_bulk(&compressor, &values, "ragged");
+
+    // One long value beside many short ones leaves the cursors badly unbalanced.
+    let mut skewed: Vec<&[u8]> = vec![long];
+    skewed.extend(std::iter::repeat_n(b"xy".as_slice(), scaled(64, 8)));
+    check_bulk(&compressor, &skewed, "skewed");
+}
+
+#[test]
+fn test_compress_bulk_into_appends() {
+    let lines: Vec<&[u8]> = PREAMBLE.as_bytes().split(|&b| b == b'\n').collect();
+    let compressor = Compressor::train(&lines);
+
+    let mut fresh_output = Vec::new();
+    let mut fresh_offsets = Vec::new();
+    compressor.compress_bulk_into(&lines, &mut fresh_output, &mut fresh_offsets);
+
+    // Existing contents are preserved, and the offsets returned are absolute indices into the
+    // output, so they are shifted by whatever was already there.
+    let mut output = vec![0xAA; 5];
+    let mut offsets = vec![u64::MAX; 2];
+    compressor.compress_bulk_into(&lines, &mut output, &mut offsets);
+
+    assert_eq!(&output[..5], &[0xAA; 5]);
+    assert_eq!(&offsets[..2], &[u64::MAX; 2]);
+    assert_eq!(&output[5..], &fresh_output[..]);
+    for (shifted, fresh) in offsets[2..].iter().zip(&fresh_offsets) {
+        assert_eq!(*shifted, fresh + 5);
+    }
+}
+
+#[test]
+fn test_compress_bulk_into_cursor_counts_agree() {
+    let corpus = &DECLARATION.as_bytes()[..scaled(DECLARATION.len(), 512)];
+    let lines: Vec<&[u8]> = corpus.split(|&b| b == b'\n').collect();
+    let compressor = Compressor::train(&lines);
+
+    let mut expected_output = Vec::new();
+    let mut expected_offsets = Vec::new();
+    compressor.compress_bulk_lanes::<1>(&lines, &mut expected_output, &mut expected_offsets);
+
+    // The cursor count is a scheduling choice; it must not change a single output byte.
+    fn compare<const K: usize>(c: &Compressor, lines: &[&[u8]], output: &[u8], offsets: &[u64]) {
+        let mut got_output = Vec::new();
+        let mut got_offsets = Vec::new();
+        c.compress_bulk_lanes::<K>(lines, &mut got_output, &mut got_offsets);
+        assert_eq!(got_output, output, "K={K} output");
+        assert_eq!(got_offsets, offsets, "K={K} offsets");
+    }
+    compare::<2>(&compressor, &lines, &expected_output, &expected_offsets);
+    compare::<3>(&compressor, &lines, &expected_output, &expected_offsets);
+    compare::<4>(&compressor, &lines, &expected_output, &expected_offsets);
+    compare::<8>(&compressor, &lines, &expected_output, &expected_offsets);
+}
+
+/// Every cursor is handed an output slice sized at two bytes per byte of its own input, which is
+/// exactly what an all-escape value consumes. An empty symbol table makes every value hit that
+/// bound at once, so nothing is left over for a cursor that overruns its slice.
+#[test]
+fn test_compress_bulk_into_all_escape_fills_every_slice() {
+    let compressor = CompressorBuilder::new().build();
+
+    // Lengths either side of a word, so cursors reach the bound both inside the interleaved
+    // loop and in the per-value remainder.
+    let owned: Vec<Vec<u8>> = (0..scaled(64, 12))
+        .map(|i| (0..=255u8).cycle().take(i * 3 + 1).collect())
+        .collect();
+    let values: Vec<&[u8]> = owned.iter().map(|value| value.as_slice()).collect();
+
+    let mut output = Vec::new();
+    let mut offsets = Vec::new();
+    compressor.compress_bulk_into(&values, &mut output, &mut offsets);
+
+    let mut start = 0usize;
+    for (i, value) in values.iter().enumerate() {
+        let end = offsets[i] as usize;
+        assert_eq!(
+            end - start,
+            value.len() * 2,
+            "value {i} should be all escapes"
+        );
+        assert_eq!(
+            compressor.decompressor().decompress(&output[start..end]),
+            *value
+        );
+        start = end;
+    }
+    assert_eq!(start, output.len());
+}


### PR DESCRIPTION
This ended up being a long profiling session where if you make the hash table lookup unconditional and then interleave 4 independent lookahead pointers (instead of 1) you end up gaining roughly 50% throughput improvement in compression